### PR TITLE
Bugfix NetFlow/IPFIX producer

### DIFF
--- a/producer/producer_nf.go
+++ b/producer/producer_nf.go
@@ -254,6 +254,10 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 		// Mac
 		case netflow.NFV9_FIELD_IN_SRC_MAC:
 			DecodeUNumber(v, &(flowMessage.SrcMac))
+		case netflow.NFV9_FIELD_IN_DST_MAC:
+			DecodeUNumber(v, &(flowMessage.DstMac))
+		case netflow.NFV9_FIELD_OUT_SRC_MAC:
+			DecodeUNumber(v, &(flowMessage.SrcMac))
 		case netflow.NFV9_FIELD_OUT_DST_MAC:
 			DecodeUNumber(v, &(flowMessage.DstMac))
 

--- a/utils/sflow_test.go
+++ b/utils/sflow_test.go
@@ -12,8 +12,7 @@ func TestDecodeFlowExpandedSFlow(t *testing.T) {
 		Payload: getExpandedSFlowDecode(),
 	}
 
-	s := &StateSFlow{
-	}
+	s := &StateSFlow{}
 
 	assert.Nil(t, s.DecodeFlow(msg))
 }


### PR DESCRIPTION
Source and destination mac addresses are fed from `NFV9_FIELD_xx_yyy_MAC`
Closes #15 where the samples were missing either source or destination Mac.
This is supposed to be linked to the sampling direction.