### PR TITLE
Fix clickhouse startup after restart

### DIFF
--- a/compose/kcg/clickhouse/create.sh
+++ b/compose/kcg/clickhouse/create.sh
@@ -3,9 +3,9 @@ set -e
 
 clickhouse client -n <<-EOSQL
 
-    CREATE DATABASE dictionaries;
+    CREATE DATABASE IF NOT EXISTS dictionaries;
     
-    CREATE DICTIONARY dictionaries.protocols (
+    CREATE DICTIONARY IF NOT EXISTS dictionaries.protocols (
         proto UInt8,
         name String,
         description String


### PR DESCRIPTION
Without it, you will get the error:
```
/entrypoint.sh: sourcing /docker-entrypoint-initdb.d/create.sh
Received exception from server (version 21.5.6):
Code: 82. DB::Exception: Received from localhost:9000. DB::Exception: Database dictionaries already exists.
```