### PR TITLE
Converts sFlow if_counters struct to prometheus metrics.

### DIFF
--- a/utils/metrics.go
+++ b/utils/metrics.go
@@ -131,6 +131,125 @@ var (
 		},
 		[]string{"router", "agent", "version", "type"}, // data-template, data, opts...
 	)
+	SFlowIfSpeed = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinspeed",
+			Help: "SFlows IfInSpeed.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfDirection = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifdirection",
+			Help: "SFlows IfDirection. 0 = unkown, 1=full-duplex, 2=half-duplex, 3 = in, 4=out.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfAdminStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifadminstatus",
+			Help: "SFlows IfAdminStatus.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOperStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifoperstatus",
+			Help: "SFlows IfOperStatus.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInOctets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinoctets",
+			Help: "SFlows IfInOctets.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInUcastPkts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinucastpkts",
+			Help: "SFlows IfInUcastPkts.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInMulticastPkts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinmulticastpkts",
+			Help: "SFlows IfInMulticastPkts.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInBroadcastPkts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinbroadcastpkts",
+			Help: "SFlows IfInBroadcastPkts.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInDiscards = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifindiscards",
+			Help: "SFlows IfInDiscards.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInErrors = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinerrors",
+			Help: "SFlows IfInErrors.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfInUnknownProtos = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifinunknownprotos",
+			Help: "SFlows IfInUnknownProtos.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOutOctets = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifoutoctets",
+			Help: "SFlows IfOutOctets.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOutUcastPkts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifoutucastpkts",
+			Help: "SFlows IfOutUcastPkts.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOutMulticastPkts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifoutmulticastpkts",
+			Help: "SFlows IfOutMulticastPkts.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOutBroadcastPkts = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifoutbroadcastpkts",
+			Help: "SFlows IfOutBroadcastPkts.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOutDiscards = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifoutdiscards",
+			Help: "SFlows IfOutDiscards.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
+	SFlowIfOutErrors = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_ifouterrors",
+			Help: "SFlows IfOutErrors.",
+		},
+		[]string{"router", "agent", "version", "type", "ifindex", "iftype"},
+	)
 )
 
 func init() {
@@ -154,6 +273,24 @@ func init() {
 	prometheus.MustRegister(SFlowErrors)
 	prometheus.MustRegister(SFlowSampleStatsSum)
 	prometheus.MustRegister(SFlowSampleRecordsStatsSum)
+
+	prometheus.MustRegister(SFlowIfSpeed)
+	prometheus.MustRegister(SFlowIfDirection)
+	prometheus.MustRegister(SFlowIfAdminStatus)
+	prometheus.MustRegister(SFlowIfOperStatus)
+	prometheus.MustRegister(SFlowIfInOctets)
+	prometheus.MustRegister(SFlowIfInUcastPkts)
+	prometheus.MustRegister(SFlowIfInMulticastPkts)
+	prometheus.MustRegister(SFlowIfInBroadcastPkts)
+	prometheus.MustRegister(SFlowIfInDiscards)
+	prometheus.MustRegister(SFlowIfInErrors)
+	prometheus.MustRegister(SFlowIfInUnknownProtos)
+	prometheus.MustRegister(SFlowIfOutOctets)
+	prometheus.MustRegister(SFlowIfOutUcastPkts)
+	prometheus.MustRegister(SFlowIfOutMulticastPkts)
+	prometheus.MustRegister(SFlowIfOutBroadcastPkts)
+	prometheus.MustRegister(SFlowIfOutDiscards)
+	prometheus.MustRegister(SFlowIfOutErrors)
 }
 
 func DefaultAccountCallback(name string, id int, start, end time.Time) {

--- a/utils/sflow.go
+++ b/utils/sflow.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net"
 	"time"
+	"fmt"
 
 	"github.com/netsampler/goflow2/decoders/sflow"
 	"github.com/netsampler/goflow2/format"
@@ -92,6 +93,192 @@ func (s *StateSFlow) DecodeFlow(msg interface{}) error {
 					typeStr = "Expanded" + typeStr
 				}
 				countRec = len(samplesConv.Records)
+
+				for _, records := range samplesConv.Records{
+					switch dataConv := records.Data.(type) {
+						case sflow.IfCounters:
+							SFlowIfSpeed.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfSpeed))
+							// bit 0 = ifAdminStatus (0 = down, 1 = up)
+							ifAdminStatus := float64(0)
+							if dataConv.IfStatus & 1 == 1  {
+								ifAdminStatus = 1
+							}
+							SFlowIfAdminStatus.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(ifAdminStatus)
+							// bit 1 = ifOperStatus (0 = down, 1 = up)
+							ifOperStatus := float64(0)
+							if dataConv.IfStatus & 2 == 2  {
+								ifOperStatus = 1
+							}
+							SFlowIfOperStatus.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(ifOperStatus)
+							SFlowIfDirection.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfDirection))
+							SFlowIfInOctets.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInOctets))
+							SFlowIfInUcastPkts.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInUcastPkts))
+							SFlowIfInMulticastPkts.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInMulticastPkts))
+							SFlowIfInBroadcastPkts.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInBroadcastPkts))
+							SFlowIfInDiscards.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInDiscards))
+							SFlowIfInErrors.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInErrors))
+							SFlowIfInUnknownProtos.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfInUnknownProtos))
+							SFlowIfOutOctets.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfOutOctets))
+							SFlowIfOutUcastPkts.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfOutUcastPkts))
+							SFlowIfOutMulticastPkts.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfOutMulticastPkts))
+							SFlowIfOutBroadcastPkts.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfOutBroadcastPkts))
+							SFlowIfOutDiscards.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfOutDiscards))
+							SFlowIfOutErrors.With(
+								prometheus.Labels{
+									"router":  key,
+									"agent":   agentStr,
+									"version": "5",
+									"type":    typeStr,
+									"ifindex": fmt.Sprint(dataConv.IfIndex),
+									"iftype": fmt.Sprint(dataConv.IfType),
+								}).
+								Set(float64(dataConv.IfOutErrors))
+					}
+				}
 			case sflow.ExpandedFlowSample:
 				typeStr = "ExpandedFlowSample"
 				countRec = len(samplesConv.Records)


### PR DESCRIPTION
This is very useful for me to get sFlow counters as matrics in Prometheus (see screenshot example).
It was inspired by [native implementation in sFlow-RT](https://blog.sflow.com/2019/04/prometheus-exporter.html).

<img width="1430" alt="Screenshot 2021-08-03 at 04 50 23" src="https://user-images.githubusercontent.com/7688234/127945598-24a311e7-c3cb-4285-bdae-e43a4b52e332.png">
