### PR TITLE
build: disable CGO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update --no-cache add git build-base gcc
 COPY . /build
 WORKDIR /build
 
-RUN go build -ldflags "${LDFLAGS}" -o goflow2 cmd/goflow2/main.go
+RUN CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o goflow2 cmd/goflow2/main.go
 
 FROM alpine:latest
 ARG src_dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,8 @@ LABEL org.opencontainers.image.description="${DESCRIPTION}"
 LABEL org.opencontainers.image.licenses="${LICENSE}"
 LABEL org.opencontainers.image.revision="${REV}"
 
-RUN apk update --no-cache && \
-    adduser -S -D -H -h / flow
-USER flow
+FROM scratch
+USER 1000
 COPY --from=builder /build/goflow2 /
 
 ENTRYPOINT ["./goflow2"]

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 
 .PHONY: build
 build: prepare
-	go build -ldflags $(LDFLAGS) -o $(OUTPUT) cmd/goflow2/main.go 
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o $(OUTPUT) cmd/goflow2/main.go
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
AFAIK, it is not needed and it avoids the resulting binary to depend
on the libc of the system it was compiled on. The resulting binary is
truly portable.