### PR TITLE
style: defer unlock when possible/not trivial

### DIFF
--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -282,6 +282,7 @@ func (ts *BasicTemplateSystem) GetTemplates() map[uint16]map[uint32]map[uint16]i
 
 func (ts *BasicTemplateSystem) AddTemplate(version uint16, obsDomainId uint32, template interface{}) {
 	ts.templateslock.Lock()
+	defer ts.templateslock.Unlock()
 	_, exists := ts.templates[version]
 	if exists != true {
 		ts.templates[version] = make(map[uint32]map[uint16]interface{})
@@ -300,27 +301,21 @@ func (ts *BasicTemplateSystem) AddTemplate(version uint16, obsDomainId uint32, t
 		templateId = templateIdConv.TemplateId
 	}
 	ts.templates[version][obsDomainId][templateId] = template
-	ts.templateslock.Unlock()
 }
 
 func (ts *BasicTemplateSystem) GetTemplate(version uint16, obsDomainId uint32, templateId uint16) (interface{}, error) {
 	ts.templateslock.RLock()
+	defer ts.templateslock.RUnlock()
 	templatesVersion, okver := ts.templates[version]
 	if okver {
 		templatesObsDom, okobs := templatesVersion[obsDomainId]
 		if okobs {
 			template, okid := templatesObsDom[templateId]
 			if okid {
-				ts.templateslock.RUnlock()
 				return template, nil
 			}
-			ts.templateslock.RUnlock()
-			return nil, NewErrorTemplateNotFound(version, obsDomainId, templateId, "info")
 		}
-		ts.templateslock.RUnlock()
-		return nil, NewErrorTemplateNotFound(version, obsDomainId, templateId, "info")
 	}
-	ts.templateslock.RUnlock()
 	return nil, NewErrorTemplateNotFound(version, obsDomainId, templateId, "info")
 }
 

--- a/format/format.go
+++ b/format/format.go
@@ -53,12 +53,12 @@ func FindFormat(ctx context.Context, name string) (*Format, error) {
 
 func GetFormats() []string {
 	lock.RLock()
+	defer lock.RUnlock()
 	t := make([]string, len(formatDrivers))
 	var i int
 	for k, _ := range formatDrivers {
 		t[i] = k
 		i++
 	}
-	lock.RUnlock()
 	return t
 }

--- a/producer/producer_nf.go
+++ b/producer/producer_nf.go
@@ -33,27 +33,25 @@ func CreateSamplingSystem() SamplingRateSystem {
 
 func (s *basicSamplingRateSystem) AddSamplingRate(version uint16, obsDomainId uint32, samplingRate uint32) {
 	s.samplinglock.Lock()
+	defer s.samplinglock.Unlock()
 	_, exists := s.sampling[version]
 	if exists != true {
 		s.sampling[version] = make(map[uint32]uint32)
 	}
 	s.sampling[version][obsDomainId] = samplingRate
-	s.samplinglock.Unlock()
 }
 
 func (s *basicSamplingRateSystem) GetSamplingRate(version uint16, obsDomainId uint32) (uint32, error) {
 	s.samplinglock.RLock()
+	defer s.samplinglock.RUnlock()
 	samplingVersion, okver := s.sampling[version]
 	if okver {
 		samplingRate, okid := samplingVersion[obsDomainId]
 		if okid {
-			s.samplinglock.RUnlock()
 			return samplingRate, nil
 		}
-		s.samplinglock.RUnlock()
 		return 0, errors.New("") // TBC
 	}
-	s.samplinglock.RUnlock()
 	return 0, errors.New("") // TBC
 }
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -57,12 +57,12 @@ func FindTransport(ctx context.Context, name string) (*Transport, error) {
 
 func GetTransports() []string {
 	lock.RLock()
+	defer lock.RUnlock()
 	t := make([]string, len(transportDrivers))
 	var i int
 	for k, _ := range transportDrivers {
 		t[i] = k
 		i++
 	}
-	lock.RUnlock()
 	return t
 }


### PR DESCRIPTION
Defer unlocking just after taking a lock when possible (when unlock is
done at the very end) and when not trivial (the function body is more
than a couple of lines). This simplifies a bit some functions (no need
to unlock before each return) and for the other, it may avoid a bug in
the future in case a return is inserted into the body of a function.

Use of defer has been optimized a lot in Go and it is believed that
simpler defers have zero overhead since Go 1.14:
https://golang.org/doc/go1.14#runtime

> This release improves the performance of most uses of defer to incur
> almost zero overhead compared to calling the deferred function
> directly. As a result, defer can now be used in performance-critical
> code without overhead concerns.