### PR TITLE
netflow: correctly decode options template set

### DIFF
--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -35,7 +35,10 @@ func DecodeNFv9OptionsTemplateSet(payload *bytes.Buffer) ([]NFv9OptionsTemplateR
 		fields := make([]Field, sizeScope)
 		for i := 0; i < sizeScope; i++ {
 			field := Field{}
-			err = utils.BinaryDecoder(payload, &field)
+			err := utils.BinaryDecoder(payload, &field.Type, &field.Length)
+			if err != nil {
+				return records, err
+			}
 			fields[i] = field
 		}
 		optsTemplateRecord.Scopes = fields
@@ -43,7 +46,10 @@ func DecodeNFv9OptionsTemplateSet(payload *bytes.Buffer) ([]NFv9OptionsTemplateR
 		fields = make([]Field, sizeOptions)
 		for i := 0; i < sizeOptions; i++ {
 			field := Field{}
-			err = utils.BinaryDecoder(payload, &field)
+			err := utils.BinaryDecoder(payload, &field.Type, &field.Length)
+			if err != nil {
+				return records, err
+			}
 			fields[i] = field
 		}
 		optsTemplateRecord.Options = fields

--- a/decoders/netflowlegacy/netflow.go
+++ b/decoders/netflowlegacy/netflow.go
@@ -23,7 +23,10 @@ func (e *ErrorVersion) Error() string {
 
 func DecodeMessage(payload *bytes.Buffer) (interface{}, error) {
 	var version uint16
-	utils.BinaryDecoder(payload, &version)
+	err := utils.BinaryDecoder(payload, &version)
+	if err != nil {
+		return nil, err
+	}
 	packet := PacketNetFlowV5{}
 	if version == 5 {
 		packet.Version = version
@@ -42,7 +45,10 @@ func DecodeMessage(payload *bytes.Buffer) (interface{}, error) {
 		packet.Records = make([]RecordsNetFlowV5, int(packet.Count))
 		for i := 0; i < int(packet.Count) && payload.Len() >= 48; i++ {
 			record := RecordsNetFlowV5{}
-			utils.BinaryDecoder(payload, &record)
+			err := utils.BinaryDecoder(payload, &record)
+			if err != nil {
+				return packet, err
+			}
 			packet.Records[i] = record
 		}
 

--- a/decoders/sflow/sflow.go
+++ b/decoders/sflow/sflow.go
@@ -81,11 +81,17 @@ func DecodeCounterRecord(header *RecordHeader, payload *bytes.Buffer) (CounterRe
 	switch (*header).DataFormat {
 	case 1:
 		ifCounters := IfCounters{}
-		utils.BinaryDecoder(payload, &ifCounters)
+		err := utils.BinaryDecoder(payload, &ifCounters)
+		if err != nil {
+			return counterRecord, err
+		}
 		counterRecord.Data = ifCounters
 	case 2:
 		ethernetCounters := EthernetCounters{}
-		utils.BinaryDecoder(payload, &ethernetCounters)
+		err := utils.BinaryDecoder(payload, &ethernetCounters)
+		if err != nil {
+			return counterRecord, err
+		}
 		counterRecord.Data = ethernetCounters
 	default:
 		return counterRecord, NewErrorDataFormat((*header).DataFormat)
@@ -96,7 +102,10 @@ func DecodeCounterRecord(header *RecordHeader, payload *bytes.Buffer) (CounterRe
 
 func DecodeIP(payload *bytes.Buffer) (uint32, []byte, error) {
 	var ipVersion uint32
-	utils.BinaryDecoder(payload, &ipVersion)
+	err := utils.BinaryDecoder(payload, &ipVersion)
+	if err != nil {
+		return 0, nil, err
+	}
 	var ip []byte
 	if ipVersion == 1 {
 		ip = make([]byte, 4)
@@ -106,7 +115,10 @@ func DecodeIP(payload *bytes.Buffer) (uint32, []byte, error) {
 		return ipVersion, ip, NewErrorIPVersion(ipVersion)
 	}
 	if payload.Len() >= len(ip) {
-		utils.BinaryDecoder(payload, &ip)
+		err := utils.BinaryDecoder(payload, &ip)
+		if err != nil {
+			return 0, nil, err
+		}
 	} else {
 		return ipVersion, ip, NewErrorDecodingSFlow(fmt.Sprintf("Not enough data: %v, needs %v.", payload.Len(), len(ip)))
 	}
@@ -354,7 +366,10 @@ func DecodeMessage(payload *bytes.Buffer) (interface{}, error) {
 		var ip []byte
 		if packetV5.IPVersion == 1 {
 			ip = make([]byte, 4)
-			utils.BinaryDecoder(payload, ip)
+			err = utils.BinaryDecoder(payload, ip)
+			if err != nil {
+				return packetV5, err
+			}
 		} else if packetV5.IPVersion == 2 {
 			ip = make([]byte, 16)
 			err = utils.BinaryDecoder(payload, ip)


### PR DESCRIPTION
The Field type does not match the format on the wire. Decode each
member individually.

Also, a second commit:

The error handling was inconsistent when using `utils.BinaryDecoder`.
All occurrences are now checked an we return early with error and the
incomplete data collected up to now when possible. This can happen
on short packets.
