### PR TITLE
Allow Flow Routines to be cancellable

### DIFF
--- a/utils/netflow.go
+++ b/utils/netflow.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -373,7 +374,13 @@ func (s *StateNetFlow) initConfig() {
 }
 
 func (s *StateNetFlow) FlowRoutine(workers int, addr string, port int, reuseport bool) error {
+	return s.FlowRoutineWithCtx(context.Background(), workers, addr, port, reuseport)
+}
+
+// FlowRoutineWithCtx starts the flow routine with a context that can be cancelled to stop the
+// routine execution
+func (s *StateNetFlow) FlowRoutineWithCtx(ctx context.Context, workers int, addr string, port int, reuseport bool) error {
 	s.InitTemplates()
 	s.initConfig()
-	return UDPRoutine("NetFlow", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
+	return UDPRoutineWithCtx(ctx, "NetFlow", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
 }

--- a/utils/nflegacy.go
+++ b/utils/nflegacy.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	"github.com/netsampler/goflow2/decoders/netflowlegacy"
@@ -95,5 +96,11 @@ func (s *StateNFLegacy) DecodeFlow(msg interface{}) error {
 }
 
 func (s *StateNFLegacy) FlowRoutine(workers int, addr string, port int, reuseport bool) error {
-	return UDPRoutine("NetFlowV5", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
+	return s.FlowRoutineWithCtx(context.Background(), workers, addr, port, reuseport)
+}
+
+// FlowRoutineWithCtx starts the flow routine with a context that can be cancelled to stop the
+// routine execution
+func (s *StateNFLegacy) FlowRoutineWithCtx(ctx context.Context, workers int, addr string, port int, reuseport bool) error {
+	return UDPRoutineWithCtx(ctx, "NetFlowV5", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
 }

--- a/utils/sflow.go
+++ b/utils/sflow.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"time"
 
@@ -153,6 +154,12 @@ func (s *StateSFlow) initConfig() {
 }
 
 func (s *StateSFlow) FlowRoutine(workers int, addr string, port int, reuseport bool) error {
+	return s.FlowRoutineWithCtx(context.Background(), workers, addr, port, reuseport)
+}
+
+// FlowRoutineWithCtx starts the flow routine with a context that can be cancelled to stop the
+// routine execution
+func (s *StateSFlow) FlowRoutineWithCtx(ctx context.Context, workers int, addr string, port int, reuseport bool) error {
 	s.initConfig()
-	return UDPRoutine("sFlow", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
+	return UDPRoutineWithCtx(ctx, "sFlow", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
 }

--- a/utils/stopper.go
+++ b/utils/stopper.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"errors"
+)
+
+// ErrAlreadyStarted error happens when you try to start twice a flow routine
+var ErrAlreadyStarted = errors.New("the routine is already started")
+
+// stopper mechanism, common for all the flow routines
+type stopper struct {
+	stopCh chan struct{}
+}
+
+func (s *stopper) start() error {
+	if s.stopCh != nil {
+		return ErrAlreadyStarted
+	}
+	s.stopCh = make(chan struct{})
+	return nil
+}
+
+func (s *stopper) Shutdown() {
+	if s.stopCh != nil {
+		close(s.stopCh)
+		s.stopCh = nil
+	}
+}

--- a/utils/stopper_test.go
+++ b/utils/stopper_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,13 @@ func TestStopper(t *testing.T) {
 	require.NoError(t, r.StartRoutine())
 	assert.True(t, r.Running)
 	r.Shutdown()
+	assert.Eventually(t, func() bool {
+		return r.Running == false
+	}, time.Second, time.Millisecond)
+
+	// after shutdown, we can start it again
+	require.NoError(t, r.StartRoutine())
+	assert.True(t, r.Running)
 }
 
 func TestStopper_CannotStartTwice(t *testing.T) {

--- a/utils/stopper_test.go
+++ b/utils/stopper_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopper(t *testing.T) {
+	r := routine{}
+	require.False(t, r.Running)
+	require.NoError(t, r.StartRoutine())
+	assert.True(t, r.Running)
+	r.Shutdown()
+}
+
+func TestStopper_CannotStartTwice(t *testing.T) {
+	r := routine{}
+	require.False(t, r.Running)
+	require.NoError(t, r.StartRoutine())
+	assert.ErrorIs(t, r.StartRoutine(), ErrAlreadyStarted)
+}
+
+type routine struct {
+	stopper
+	Running bool
+}
+
+func (p *routine) StartRoutine() error {
+	if err := p.start(); err != nil {
+		return err
+	}
+	p.Running = true
+	waitForGoRoutine := make(chan struct{})
+	go func() {
+		close(waitForGoRoutine)
+		<-p.stopCh
+		p.Running = false
+	}()
+	<-waitForGoRoutine
+	return nil
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelUDPRoutine(t *testing.T) {
+	testTimeout := time.After(10 * time.Second)
+	port, err := getFreeUDPPort()
+	require.NoError(t, err)
+	ctx, cancelContext := context.WithCancel(context.Background())
+	receivedMessages := make(chan interface{})
+	go func() {
+		require.NoError(t, UDPRoutineWithCtx(ctx, "test_udp", func(msg interface{}) error {
+			receivedMessages <- msg
+			return nil
+		}, 1, "127.0.0.1", port, false, logrus.StandardLogger()))
+	}()
+
+	// wait slightly so we give time to the server to accept requests
+	time.Sleep(100 * time.Millisecond)
+
+	sendMessage := func(msg string) error {
+		conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+		_, err = conn.Write([]byte(msg))
+		return err
+	}
+	require.NoError(t, sendMessage("message 1"))
+	require.NoError(t, sendMessage("message 2"))
+	require.NoError(t, sendMessage("message 3"))
+
+	readMessage := func() string {
+		select {
+		case msg := <-receivedMessages:
+			return string(msg.(BaseMessage).Payload)
+		case <-testTimeout:
+			require.Fail(t, "test timed out while waiting for message")
+			return ""
+		}
+	}
+
+	require.Equal(t, "message 1", readMessage())
+	require.Equal(t, "message 2", readMessage())
+	require.Equal(t, "message 3", readMessage())
+
+	cancelContext()
+
+	_ = sendMessage("no more messages should be processed")
+
+	select {
+	case msg := <-receivedMessages:
+		assert.Fail(t, fmt.Sprint(msg))
+	default:
+		// everything is correct
+	}
+}
+
+func getFreeUDPPort() (int, error) {
+	a, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenUDP("udp", a)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.LocalAddr().(*net.UDPAddr).Port, nil
+}


### PR DESCRIPTION
When Goflow2 is consumed as a Go library, we'd need some tools to allow cancelling the Flow ingestion routines (e.g. to retry a connection).

This PR adds new `Shutdown` methods that interrupt the flow routines, by means of a new `utils.UDPStoppableRoutine` function. The `utils_test.go` and `stopper_test.go` files shows how the mechanism works