### PR TITLE
Fix enricher buffer issue

### DIFF
--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -150,18 +150,19 @@ func main() {
 	msgLen := make([]byte, binary.MaxVarintLen64)
 	lenBufSize := len(msgLen)
 	for {
-		n, err := rdr.Read(msgLen)
+		n, err := io.ReadFull(rdr, msgLen)
 		if err != nil && err != io.EOF {
 			log.Error(err)
 			continue
 		}
 
-		len, vn := proto.DecodeVarint(msgLen[0:n])
-		if len == 0 {
+		l, vn := proto.DecodeVarint(msgLen[0:n])
+		if l == 0 {
 			continue
 		}
 
-		line := make([]byte, len)
+		line := make([]byte, l)
+
 		if vn < lenBufSize {
 			copy(line[0:lenBufSize-vn], msgLen[vn:lenBufSize])
 		}


### PR DESCRIPTION
Hotfix the issue in #66 with `ReadFull`.
Forces to wait until whole protobuf varint prefix with size is loaded.
Need to handle edge case if protobuf size + varint < 10 bytes (the max size of varint which is the size of the buffer)