### PR TITLE
Avoid unnecessary memory allocations

### DIFF
--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -17,7 +17,7 @@ type NetFlowTemplateSystem interface {
 }
 
 func DecodeNFv9OptionsTemplateSet(payload *bytes.Buffer) ([]NFv9OptionsTemplateRecord, error) {
-	records := make([]NFv9OptionsTemplateRecord, 0)
+	var records []NFv9OptionsTemplateRecord
 	var err error
 	for payload.Len() >= 4 {
 		optsTemplateRecord := NFv9OptionsTemplateRecord{}
@@ -68,7 +68,7 @@ func DecodeField(payload *bytes.Buffer, field *Field, pen bool) error {
 }
 
 func DecodeIPFIXOptionsTemplateSet(payload *bytes.Buffer) ([]IPFIXOptionsTemplateRecord, error) {
-	records := make([]IPFIXOptionsTemplateRecord, 0)
+	var records []IPFIXOptionsTemplateRecord
 	var err error
 	for payload.Len() >= 4 {
 		optsTemplateRecord := IPFIXOptionsTemplateRecord{}
@@ -108,7 +108,7 @@ func DecodeIPFIXOptionsTemplateSet(payload *bytes.Buffer) ([]IPFIXOptionsTemplat
 }
 
 func DecodeTemplateSet(version uint16, payload *bytes.Buffer) ([]TemplateRecord, error) {
-	records := make([]TemplateRecord, 0)
+	var records []TemplateRecord
 	var err error
 	for payload.Len() >= 4 {
 		templateRecord := TemplateRecord{}
@@ -214,7 +214,7 @@ func (e *ErrorTemplateNotFound) Error() string {
 }
 
 func DecodeOptionsDataSet(version uint16, payload *bytes.Buffer, listFieldsScopes, listFieldsOption []Field) ([]OptionsDataRecord, error) {
-	records := make([]OptionsDataRecord, 0)
+	var records []OptionsDataRecord
 
 	listFieldsScopesSize := GetTemplateSize(version, listFieldsScopes)
 	listFieldsOptionSize := GetTemplateSize(version, listFieldsOption)
@@ -234,7 +234,7 @@ func DecodeOptionsDataSet(version uint16, payload *bytes.Buffer, listFieldsScope
 }
 
 func DecodeDataSet(version uint16, payload *bytes.Buffer, listFields []Field) ([]DataRecord, error) {
-	records := make([]DataRecord, 0)
+	var records []DataRecord
 
 	listFieldsSize := GetTemplateSize(version, listFields)
 	for payload.Len() >= listFieldsSize {

--- a/decoders/sflow/sflow.go
+++ b/decoders/sflow/sflow.go
@@ -206,7 +206,7 @@ func DecodeFlowRecord(header *RecordHeader, payload *bytes.Buffer) (FlowRecord, 
 		if err != nil {
 			return flowRecord, err
 		}
-		asPath := make([]uint32, 0)
+		var asPath []uint32
 		if extendedGateway.ASDestinations != 0 {
 			err := utils.BinaryDecoder(payload, &(extendedGateway.ASPathType), &(extendedGateway.ASPathLength))
 			if err != nil {

--- a/producer/producer_nf.go
+++ b/producer/producer_nf.go
@@ -400,7 +400,7 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 }
 
 func SearchNetFlowDataSetsRecords(version uint16, baseTime uint32, uptime uint32, dataRecords []netflow.DataRecord, mapperNetFlow *NetFlowMapper, mapperSFlow *SFlowMapper) []*flowmessage.FlowMessage {
-	flowMessageSet := make([]*flowmessage.FlowMessage, 0)
+	var flowMessageSet []*flowmessage.FlowMessage
 	for _, record := range dataRecords {
 		fmsg := ConvertNetFlowDataSet(version, baseTime, uptime, record.Values, mapperNetFlow, mapperSFlow)
 		if fmsg != nil {
@@ -411,7 +411,7 @@ func SearchNetFlowDataSetsRecords(version uint16, baseTime uint32, uptime uint32
 }
 
 func SearchNetFlowDataSets(version uint16, baseTime uint32, uptime uint32, dataFlowSet []netflow.DataFlowSet, mapperNetFlow *NetFlowMapper, mapperSFlow *SFlowMapper) []*flowmessage.FlowMessage {
-	flowMessageSet := make([]*flowmessage.FlowMessage, 0)
+	var flowMessageSet []*flowmessage.FlowMessage
 	for _, dataFlowSetItem := range dataFlowSet {
 		fmsg := SearchNetFlowDataSetsRecords(version, baseTime, uptime, dataFlowSetItem.Records, mapperNetFlow, mapperSFlow)
 		if fmsg != nil {
@@ -444,40 +444,40 @@ func SearchNetFlowOptionDataSets(dataFlowSet []netflow.OptionsDataFlowSet) (uint
 }
 
 func SplitNetFlowSets(packetNFv9 netflow.NFv9Packet) ([]netflow.DataFlowSet, []netflow.TemplateFlowSet, []netflow.NFv9OptionsTemplateFlowSet, []netflow.OptionsDataFlowSet) {
-	dataFlowSet := make([]netflow.DataFlowSet, 0)
-	templatesFlowSet := make([]netflow.TemplateFlowSet, 0)
-	optionsTemplatesFlowSet := make([]netflow.NFv9OptionsTemplateFlowSet, 0)
-	optionsDataFlowSet := make([]netflow.OptionsDataFlowSet, 0)
+	var dataFlowSet []netflow.DataFlowSet
+	var templatesFlowSet []netflow.TemplateFlowSet
+	var optionsTemplatesFlowSet []netflow.NFv9OptionsTemplateFlowSet
+	var optionsDataFlowSet []netflow.OptionsDataFlowSet
 	for _, flowSet := range packetNFv9.FlowSets {
-		switch flowSet.(type) {
+		switch tFlowSet := flowSet.(type) {
 		case netflow.TemplateFlowSet:
-			templatesFlowSet = append(templatesFlowSet, flowSet.(netflow.TemplateFlowSet))
+			templatesFlowSet = append(templatesFlowSet, tFlowSet)
 		case netflow.NFv9OptionsTemplateFlowSet:
-			optionsTemplatesFlowSet = append(optionsTemplatesFlowSet, flowSet.(netflow.NFv9OptionsTemplateFlowSet))
+			optionsTemplatesFlowSet = append(optionsTemplatesFlowSet, tFlowSet)
 		case netflow.DataFlowSet:
-			dataFlowSet = append(dataFlowSet, flowSet.(netflow.DataFlowSet))
+			dataFlowSet = append(dataFlowSet, tFlowSet)
 		case netflow.OptionsDataFlowSet:
-			optionsDataFlowSet = append(optionsDataFlowSet, flowSet.(netflow.OptionsDataFlowSet))
+			optionsDataFlowSet = append(optionsDataFlowSet, tFlowSet)
 		}
 	}
 	return dataFlowSet, templatesFlowSet, optionsTemplatesFlowSet, optionsDataFlowSet
 }
 
 func SplitIPFIXSets(packetIPFIX netflow.IPFIXPacket) ([]netflow.DataFlowSet, []netflow.TemplateFlowSet, []netflow.IPFIXOptionsTemplateFlowSet, []netflow.OptionsDataFlowSet) {
-	dataFlowSet := make([]netflow.DataFlowSet, 0)
-	templatesFlowSet := make([]netflow.TemplateFlowSet, 0)
-	optionsTemplatesFlowSet := make([]netflow.IPFIXOptionsTemplateFlowSet, 0)
-	optionsDataFlowSet := make([]netflow.OptionsDataFlowSet, 0)
+	var dataFlowSet []netflow.DataFlowSet
+	var templatesFlowSet []netflow.TemplateFlowSet
+	var optionsTemplatesFlowSet []netflow.IPFIXOptionsTemplateFlowSet
+	var optionsDataFlowSet []netflow.OptionsDataFlowSet
 	for _, flowSet := range packetIPFIX.FlowSets {
-		switch flowSet.(type) {
+		switch tFlowSet := flowSet.(type) {
 		case netflow.TemplateFlowSet:
-			templatesFlowSet = append(templatesFlowSet, flowSet.(netflow.TemplateFlowSet))
+			templatesFlowSet = append(templatesFlowSet, tFlowSet)
 		case netflow.IPFIXOptionsTemplateFlowSet:
-			optionsTemplatesFlowSet = append(optionsTemplatesFlowSet, flowSet.(netflow.IPFIXOptionsTemplateFlowSet))
+			optionsTemplatesFlowSet = append(optionsTemplatesFlowSet, tFlowSet)
 		case netflow.DataFlowSet:
-			dataFlowSet = append(dataFlowSet, flowSet.(netflow.DataFlowSet))
+			dataFlowSet = append(dataFlowSet, tFlowSet)
 		case netflow.OptionsDataFlowSet:
-			optionsDataFlowSet = append(optionsDataFlowSet, flowSet.(netflow.OptionsDataFlowSet))
+			optionsDataFlowSet = append(optionsDataFlowSet, tFlowSet)
 		}
 	}
 	return dataFlowSet, templatesFlowSet, optionsTemplatesFlowSet, optionsDataFlowSet
@@ -494,7 +494,7 @@ func ProcessMessageNetFlowConfig(msgDec interface{}, samplingRateSys SamplingRat
 	var baseTime uint32
 	var uptime uint32
 
-	flowMessageSet := make([]*flowmessage.FlowMessage, 0)
+	var flowMessageSet []*flowmessage.FlowMessage
 
 	switch msgDecConv := msgDec.(type) {
 	case netflow.NFv9Packet:

--- a/producer/producer_nflegacy.go
+++ b/producer/producer_nflegacy.go
@@ -48,7 +48,7 @@ func ConvertNetFlowLegacyRecord(baseTime uint32, uptime uint32, record netflowle
 }
 
 func SearchNetFlowLegacyRecords(baseTime uint32, uptime uint32, dataRecords []netflowlegacy.RecordsNetFlowV5) []*flowmessage.FlowMessage {
-	flowMessageSet := make([]*flowmessage.FlowMessage, 0)
+	var flowMessageSet []*flowmessage.FlowMessage
 	for _, record := range dataRecords {
 		fmsg := ConvertNetFlowLegacyRecord(baseTime, uptime, record)
 		if fmsg != nil {

--- a/producer/producer_sf.go
+++ b/producer/producer_sf.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetSFlowFlowSamples(packet *sflow.Packet) []interface{} {
-	flowSamples := make([]interface{}, 0)
+	var flowSamples []interface{}
 	for _, sample := range packet.Samples {
 		switch sample.(type) {
 		case sflow.FlowSample:
@@ -236,7 +236,7 @@ func SearchSFlowSamples(samples []interface{}) []*flowmessage.FlowMessage {
 }
 
 func SearchSFlowSamplesConfig(samples []interface{}, config *SFlowMapper) []*flowmessage.FlowMessage {
-	flowMessageSet := make([]*flowmessage.FlowMessage, 0)
+	var flowMessageSet []*flowmessage.FlowMessage
 
 	for _, flowSample := range samples {
 		var records []sflow.FlowRecord

--- a/producer/reflect.go
+++ b/producer/reflect.go
@@ -157,13 +157,9 @@ func MapFieldsSFlow(fields []SFlowMapField) *SFlowMapper {
 			Length:      field.Length,
 			Destination: field.Destination,
 		}
-		retLayer, ok := ret[field.Layer]
-		if !ok {
-			retLayer = make([]DataMapLayer, 0)
-		}
+		retLayer := ret[field.Layer]
 		retLayer = append(retLayer, retLayerEntry)
 		ret[field.Layer] = retLayer
-
 	}
 	return &SFlowMapper{ret}
 }

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -98,7 +98,7 @@ func (d *KafkaDriver) Init(context.Context) error {
 		}
 	}
 
-	addrs := make([]string, 0)
+	var addrs []string
 	if d.kafkaSrv != "" {
 		addrs, _ = utils.GetServiceAddresses(d.kafkaSrv)
 	} else {

--- a/utils/netflow.go
+++ b/utils/netflow.go
@@ -125,7 +125,7 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 		return err
 	}
 
-	flowMessageSet := make([]*flowmessage.FlowMessage, 0)
+	var flowMessageSet []*flowmessage.FlowMessage
 
 	switch msgDecConv := msgDec.(type) {
 	case netflow.NFv9Packet:


### PR DESCRIPTION
Zero-length slice allocations might result in an unnecessary memory allocation if you don't add later data to the slices, which could result in multiple unnecessary allocations per flow received.

This PR suggests to replace constructs like:

```go
templatesFlowSet := make([]netflow.TemplateFlowSet, 0)
```

by:

```go
var templatesFlowSet []netflow.TemplateFlowSet
```

The code is still safe against `nil` references to slice, as Go allows operating with `nil` slices in the `len`, `append` and `range` operators:

If e.g. `templatesFlowSet == nil`:
* `len(templatesFlowSet)` == 0
* `templatesFlowSet = append(templatesFlowSet, XX)` will return a new slice with XX appended.
* `for i, v := range templatesFlowSet` will be a zero-iteration loop.

