### PR TITLE
support netflow v9 variable length

### DIFF
--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -145,7 +145,7 @@ func DecodeTemplateSet(version uint16, payload *bytes.Buffer) ([]TemplateRecord,
 func GetTemplateSize(version uint16, template []Field) int {
 	sum := 0
 	for _, templateField := range template {
-		if version == 10 && templateField.Length == 0xffff {
+		if templateField.Length == 0xffff {
 			continue
 		}
 
@@ -161,7 +161,7 @@ func DecodeDataSetUsingFields(version uint16, payload *bytes.Buffer, listFields 
 		for i, templateField := range listFields {
 
 			finalLength := int(templateField.Length)
-			if version == 10 && templateField.Length == 0xffff {
+			if templateField.Length == 0xffff {
 				var variableLen8 byte
 				var variableLen16 uint16
 				err := utils.BinaryDecoder(payload, &variableLen8)


### PR DESCRIPTION
There are no mentions of variable length (a [RFC7011/IPFIX feature originally](https://datatracker.ietf.org/doc/html/rfc7011)) in Cisco NetFlow v9 but apparently some implementations (like H3C) send this causing the samples to not be decoded since it's expecting a total sample size of 65kB+.

Seems that Wireshark dissectors do not mind wether it's NetFlow or IPFIX.
https://github.com/wireshark/wireshark/blob/248f11dd1b15bd7322a7fb3e66238eb538c8a9e2/epan/dissectors/packet-netflow.c#L5138

This PR implements the same behavior and removes the check of the version.

Closes #76.