### PR TITLE
FIRST_SWITCHED and LAST_SWITCH not corresponding RFC or CISCO 

### DIFF
--- a/producer/producer_nf.go
+++ b/producer/producer_nf.go
@@ -340,13 +340,13 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 				case netflow.NFV9_FIELD_FIRST_SWITCHED:
 					var timeFirstSwitched uint32
 					DecodeUNumber(v, &timeFirstSwitched)
-					timeDiff := (uptime - timeFirstSwitched) / 1000
-					flowMessage.TimeFlowStart = uint64(baseTime - timeDiff)
+					timeDiff := (uptime - timeFirstSwitched)
+					flowMessage.TimeFlowStart = uint64(baseTime)*1000 - uint64(timeDiff)
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					DecodeUNumber(v, &timeLastSwitched)
-					timeDiff := (uptime - timeLastSwitched) / 1000
-					flowMessage.TimeFlowEnd = uint64(baseTime - timeDiff)
+					timeDiff := (uptime - timeLastSwitched)
+					flowMessage.TimeFlowEnd = uint64(baseTime)*1000 - uint64(timeDiff)
 				}
 			} else if version == 10 {
 				switch df.Type {


### PR DESCRIPTION
Closes #78 
[RFC 3954](https://datatracker.ietf.org/doc/html/rfc3954) and [NetFlow Version 9 Flow-Record Format](https://www.cisco.com/en/US/technologies/tk648/tk362/technologies_white_paper09186a00800a3db9.html) both specify the fields `FIRST_SWITCHED` and `LAST_SWITCHED` as **System uptime in milliseconds**, however, goflow2 produces them in seconds:
https://github.com/netsampler/goflow2/blob/58f0f97a629cf0cc1d1786c06a27ac2d107717bc/producer/producer_nf.go#L337-L350

This modifications make both of the fields to be produced in milliseconds