### PR TITLE
In IPFIX DeltaMicroseconds case, basetime must be converted to MS

### DIFF
--- a/producer/producer_nf.go
+++ b/producer/producer_nf.go
@@ -341,13 +341,13 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 					var timeFirstSwitched uint32
 					DecodeUNumber(v, &timeFirstSwitched)
 					timeDiff := (uptime - timeFirstSwitched)
-					flowMessage.TimeFlowStart = uint64(baseTime - timeDiff / 1000)
+					flowMessage.TimeFlowStart = uint64(baseTime - timeDiff/1000)
 					flowMessage.TimeFlowStartMs = uint64(baseTime)*1000 - uint64(timeDiff)
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					DecodeUNumber(v, &timeLastSwitched)
 					timeDiff := (uptime - timeLastSwitched)
-					flowMessage.TimeFlowEnd = uint64(baseTime - timeDiff / 1000)
+					flowMessage.TimeFlowEnd = uint64(baseTime - timeDiff/1000)
 					flowMessage.TimeFlowEndMs = uint64(baseTime)*1000 - uint64(timeDiff)
 				}
 			} else if version == 10 {
@@ -355,7 +355,7 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 				case netflow.IPFIX_FIELD_flowStartSeconds:
 					DecodeUNumber(v, &time)
 					flowMessage.TimeFlowStart = time
-					flowMessage.TimeFlowStartMs = time*1000
+					flowMessage.TimeFlowStartMs = time * 1000
 				case netflow.IPFIX_FIELD_flowStartMilliseconds:
 					DecodeUNumber(v, &time)
 					flowMessage.TimeFlowStart = time / 1000
@@ -371,7 +371,7 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 				case netflow.IPFIX_FIELD_flowEndSeconds:
 					DecodeUNumber(v, &time)
 					flowMessage.TimeFlowEnd = time
-					flowMessage.TimeFlowEndMs = time*1000
+					flowMessage.TimeFlowEndMs = time * 1000
 				case netflow.IPFIX_FIELD_flowEndMilliseconds:
 					DecodeUNumber(v, &time)
 					flowMessage.TimeFlowEnd = time / 1000
@@ -387,11 +387,11 @@ func ConvertNetFlowDataSet(version uint16, baseTime uint32, uptime uint32, recor
 				case netflow.IPFIX_FIELD_flowStartDeltaMicroseconds:
 					DecodeUNumber(v, &time)
 					flowMessage.TimeFlowStart = uint64(baseTime) - time/1000000
-					flowMessage.TimeFlowStartMs = uint64(baseTime) - time/1000
+					flowMessage.TimeFlowStartMs = uint64(baseTime)*1000 - time/1000
 				case netflow.IPFIX_FIELD_flowEndDeltaMicroseconds:
 					DecodeUNumber(v, &time)
 					flowMessage.TimeFlowEnd = uint64(baseTime) - time/1000000
-					flowMessage.TimeFlowEndMs = uint64(baseTime) - time/1000
+					flowMessage.TimeFlowEndMs = uint64(baseTime)*1000 - time/1000
 				// RFC7133
 				case netflow.IPFIX_FIELD_dataLinkFrameSize:
 					DecodeUNumber(v, &(flowMessage.Bytes))


### PR DESCRIPTION
`*1000`  missing to convert basetime from seconds to milliseconds in two cases