### PR TITLE
Update kafka.go to add transport.kafka.compression.type as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ To partition the feed (any field of the protobuf is available), the following op
 -format.hash=SamplerAddress,DstAS
 ```
 
+By default, Lz4 compression will be enabled when sending data to kafka
+To change the kafka compression type of the producer side configure the following options
+```
+transport.kafka.compression.type=lz4
+```
+Optionally to disable compression on the producer end configure the below parameter
+```
+transport.kafka.compression.type=none
+```
+
 ### Docker
 
 You can also run directly with a container:

--- a/README.md
+++ b/README.md
@@ -153,11 +153,20 @@ To partition the feed (any field of the protobuf is available), the following op
 By default, no compression will be enabled when sending data to kafka
 To change the kafka compression type of the producer side configure the following options
 ```
-transport.kafka.compression.type=lz4
+transport.kafka.compression.type=3
 ```
 Optionally to disable compression on the producer end configure the below parameter
 ```
-transport.kafka.compression.type=none
+transport.kafka.compression.type=0
+```
+
+List of all compression types:
+```
+CompressionNone   CompressionCodec = 0
+CompressionGZIP   CompressionCodec = 1
+CompressionSnappy CompressionCodec = 2
+CompressionLZ4    CompressionCodec = 3
+CompressionZSTD   CompressionCodec = 4
 ```
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To partition the feed (any field of the protobuf is available), the following op
 -format.hash=SamplerAddress,DstAS
 ```
 
-By default, Lz4 compression will be enabled when sending data to kafka
+By default, no compression will be enabled when sending data to kafka
 To change the kafka compression type of the producer side configure the following options
 ```
 transport.kafka.compression.type=lz4

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -55,7 +55,7 @@ func (d *KafkaDriver) Prepare() error {
 
 	//flag.StringVar(&d.kafkaKeying, "transport.kafka.key", "SamplerAddress,DstAS", "Kafka list of fields to do hashing on (partition) separated by commas")
 	flag.StringVar(&d.kafkaVersion, "transport.kafka.version", "2.8.0", "Kafka version")
-	flag.StringVar(&d.kafkaCompressionType, "transport.kafka.compression.type", "lz4", "Kafka default compression type")
+	flag.StringVar(&d.kafkaCompressionType, "transport.kafka.compression.type", "none", "Kafka default compression type")
 
 	return nil
 }

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -32,7 +32,7 @@ type KafkaDriver struct {
 
 	kafkaHashing bool
 	kafkaVersion string
-	kafkaCompressionType string
+	kafkaCompressionType int
 
 	producer sarama.AsyncProducer
 

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -32,6 +32,7 @@ type KafkaDriver struct {
 
 	kafkaHashing bool
 	kafkaVersion string
+	kafkaCompressionType string
 
 	producer sarama.AsyncProducer
 
@@ -54,6 +55,7 @@ func (d *KafkaDriver) Prepare() error {
 
 	//flag.StringVar(&d.kafkaKeying, "transport.kafka.key", "SamplerAddress,DstAS", "Kafka list of fields to do hashing on (partition) separated by commas")
 	flag.StringVar(&d.kafkaVersion, "transport.kafka.version", "2.8.0", "Kafka version")
+	flag.StringVar(&d.kafkaCompressionType, "transport.kafka.compression.type", "LZ4", "Kafka default compression type")
 
 	return nil
 }
@@ -71,6 +73,9 @@ func (d *KafkaDriver) Init(context.Context) error {
 	kafkaConfig.Producer.MaxMessageBytes = d.kafkaMaxMsgBytes
 	kafkaConfig.Producer.Flush.Bytes = d.kafkaFlushBytes
 	kafkaConfig.Producer.Flush.Frequency = d.kafkaFlushFrequency
+	kafkaConfig.Producer.Flush.Frequency = d.kafkaFlushFrequency
+	kafkaConfig.Producer.Compression = d.kafkaCompressionType
+	
 	if d.kafkaTLS {
 		rootCAs, err := x509.SystemCertPool()
 		if err != nil {

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -55,7 +55,7 @@ func (d *KafkaDriver) Prepare() error {
 
 	//flag.StringVar(&d.kafkaKeying, "transport.kafka.key", "SamplerAddress,DstAS", "Kafka list of fields to do hashing on (partition) separated by commas")
 	flag.StringVar(&d.kafkaVersion, "transport.kafka.version", "2.8.0", "Kafka version")
-	flag.StringVar(&d.kafkaCompressionType, "transport.kafka.compression.type", "none", "Kafka default compression type")
+	flag.IntVar(&d.kafkaCompressionType, "transport.kafka.compression.type", 0, "Kafka default compression type")
 
 	return nil
 }

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -55,7 +55,7 @@ func (d *KafkaDriver) Prepare() error {
 
 	//flag.StringVar(&d.kafkaKeying, "transport.kafka.key", "SamplerAddress,DstAS", "Kafka list of fields to do hashing on (partition) separated by commas")
 	flag.StringVar(&d.kafkaVersion, "transport.kafka.version", "2.8.0", "Kafka version")
-	flag.StringVar(&d.kafkaCompressionType, "transport.kafka.compression.type", "LZ4", "Kafka default compression type")
+	flag.StringVar(&d.kafkaCompressionType, "transport.kafka.compression.type", "lz4", "Kafka default compression type")
 
 	return nil
 }

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -73,7 +73,6 @@ func (d *KafkaDriver) Init(context.Context) error {
 	kafkaConfig.Producer.MaxMessageBytes = d.kafkaMaxMsgBytes
 	kafkaConfig.Producer.Flush.Bytes = d.kafkaFlushBytes
 	kafkaConfig.Producer.Flush.Frequency = d.kafkaFlushFrequency
-	kafkaConfig.Producer.Flush.Frequency = d.kafkaFlushFrequency
 	kafkaConfig.Producer.Compression = sarama.CompressionCodec(d.kafkaCompressionType)
 	
 	if d.kafkaTLS {

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -74,7 +74,7 @@ func (d *KafkaDriver) Init(context.Context) error {
 	kafkaConfig.Producer.Flush.Bytes = d.kafkaFlushBytes
 	kafkaConfig.Producer.Flush.Frequency = d.kafkaFlushFrequency
 	kafkaConfig.Producer.Flush.Frequency = d.kafkaFlushFrequency
-	kafkaConfig.Producer.Compression = d.kafkaCompressionType
+	kafkaConfig.Producer.Compression = sarama.CompressionCodec(d.kafkaCompressionType)
 	
 	if d.kafkaTLS {
 		rootCAs, err := x509.SystemCertPool()


### PR DESCRIPTION
Addresses Issue: https://github.com/netsampler/goflow2/issues/92
