### PR TITLE
socket reuse URI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ To partition the feed (any field of the protobuf is available), the following op
 -format.hash=SamplerAddress,DstAS
 ```
 
+By default, the collector will listen for IPFIX/NetFlow V9 on port 2055
+and sFlow on port 6343.
+To change the sockets binding, you can set the `-listen` argument and a URI
+for each protocol (`netflow`, `sflow` and `nfl` as scheme) separated by a comma.
+For instance, to create 4 parallel sockets of sFlow and one of NetFlow V5, you can use:
+
+```bash
+$ ./goflow2 -listen 'sflow://:6343?count=4,nfl://:2055'
+```
+
 ### Docker
 
 You can also run directly with a container:


### PR DESCRIPTION
Improve the binding URI with `?count=N` argument.
Example to create 4 sFlow sockets 

```bash
$ ./goflow2 -listen 'sflow://:6343?count=4'
```

Previously, the user would have to do:
```bash
$ ./goflow2 -listen 'sflow://:6343,sflow://:6343,sflow://:6343,sflow://:6343'
```