### PR TITLE
Silently drop 0 byte packets without processing as flow

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -166,6 +166,9 @@ func UDPStoppableRoutine(stopCh <-chan struct{}, name string, decodeFunc decoder
 			u := udpData{}
 			u.size, u.pktAddr, _ = udpconn.ReadFromUDP(payload)
 			if stopped.Load() == false {
+				if u.size == 0 { // Ignore 0 byte packets.
+					continue
+				}
 				u.payload = make([]byte, u.size)
 				copy(u.payload, payload[0:u.size])
 				udpDataCh <- u


### PR DESCRIPTION
Flow I'm trying to process will have empty packets sometimes. This results in errors like 

```NetFlow 8 36.263µs Error decoding version: EOF```

Change silently skips empty packets right after they are read. 