### PR TITLE
Fix SrcAS/DstAS for sFlow

### DIFF
--- a/producer/producer_sf.go
+++ b/producer/producer_sf.go
@@ -296,15 +296,18 @@ func SearchSFlowSamplesConfig(samples []interface{}, config *SFlowMapper) []*flo
 			case sflow.ExtendedGateway:
 				ipNh = recordData.NextHop
 				flowMessage.BgpNextHop = ipNh
-				flowMessage.SrcAS = recordData.SrcAS
 				flowMessage.BgpCommunities = recordData.Communities
 				flowMessage.AsPath = recordData.ASPath
 				if len(recordData.ASPath) > 0 {
 					flowMessage.DstAS = recordData.ASPath[len(recordData.ASPath)-1]
 					flowMessage.NextHopAS = recordData.ASPath[0]
-					flowMessage.SrcAS = recordData.AS
 				} else {
 					flowMessage.DstAS = recordData.AS
+				}
+				if recordData.SrcAS > 0 {
+					flowMessage.SrcAS = recordData.SrcAS
+				} else {
+					flowMessage.SrcAS = recordData.AS
 				}
 			case sflow.ExtendedSwitch:
 				flowMessage.SrcVlan = recordData.SrcVlan


### PR DESCRIPTION
For SrcAS, when there is an AS path, we should keep the value of the dedicated field instead of using the router AS number. For DstAS, if there is no AS path, it is better to keep it to 0 instead of trying to guess it. It may break other workflows that try to be smarter.

See https://github.com/akvorado/akvorado/issues/173.