### PR TITLE
mapping: support endianness

### DIFF
--- a/cmd/goflow2/mapping.yaml
+++ b/cmd/goflow2/mapping.yaml
@@ -16,6 +16,9 @@ netflowv9:
       destination: CustomInteger1
     - field: 11
       destination: CustomInteger2
+    - field: 34 # samplingInterval
+      destination: SamplingRate
+      endian: little
 sflow:
   mapping:
     - layer: 4 # Layer 4: TCP or UDP

--- a/producer/producer_sf.go
+++ b/producer/producer_sf.go
@@ -58,7 +58,7 @@ func ParseEthernetHeader(flowMessage *flowmessage.FlowMessage, data []byte, conf
 
 	for _, configLayer := range GetSFlowConfigLayer(config, 0) {
 		extracted := GetBytes(data, configLayer.Offset, configLayer.Length)
-		MapCustom(flowMessage, extracted, configLayer.Destination)
+		MapCustom(flowMessage, extracted, configLayer.Destination, configLayer.Endian)
 	}
 
 	etherType := data[12:14]
@@ -121,7 +121,7 @@ func ParseEthernetHeader(flowMessage *flowmessage.FlowMessage, data []byte, conf
 
 		for _, configLayer := range GetSFlowConfigLayer(config, 3) {
 			extracted := GetBytes(data, offset*8+configLayer.Offset, configLayer.Length)
-			MapCustom(flowMessage, extracted, configLayer.Destination)
+			MapCustom(flowMessage, extracted, configLayer.Destination, configLayer.Endian)
 		}
 
 		if etherType[0] == 0x8 && etherType[1] == 0x0 { // IPv4
@@ -159,7 +159,7 @@ func ParseEthernetHeader(flowMessage *flowmessage.FlowMessage, data []byte, conf
 
 		for _, configLayer := range GetSFlowConfigLayer(config, 4) {
 			extracted := GetBytes(data, offset*8+configLayer.Offset, configLayer.Length)
-			MapCustom(flowMessage, extracted, configLayer.Destination)
+			MapCustom(flowMessage, extracted, configLayer.Destination, configLayer.Endian)
 		}
 
 		appOffset := 0
@@ -187,7 +187,7 @@ func ParseEthernetHeader(flowMessage *flowmessage.FlowMessage, data []byte, conf
 		if appOffset > 0 {
 			for _, configLayer := range GetSFlowConfigLayer(config, 7) {
 				extracted := GetBytes(data, (offset+appOffset)*8+configLayer.Offset, configLayer.Length)
-				MapCustom(flowMessage, extracted, configLayer.Destination)
+				MapCustom(flowMessage, extracted, configLayer.Destination, configLayer.Endian)
 			}
 		}
 


### PR DESCRIPTION
Related to https://github.com/netsampler/goflow2/issues/113

Mapping file can specify the following:
```yaml
netflowv9:
  mapping:
    - field: 34
      destination: SamplingRate
      endian: little
```

This should support the strange implementation from Mikrotik of the Sampling Rate. This field ends up in the Data frame and not Data Options. Additionally, the records is in little endian.