### PR TITLE
add convertipv6 feature for protobuf format

### DIFF
--- a/format/protobuf/protobuf.go
+++ b/format/protobuf/protobuf.go
@@ -4,18 +4,23 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/netsampler/goflow2/format"
 	"github.com/netsampler/goflow2/format/common"
+	flowmessage "github.com/netsampler/goflow2/pb"
 )
 
 type ProtobufDriver struct {
-	fixedLen bool
+	fixedLen      bool
+	convertToIPV6 bool
 }
 
 func (d *ProtobufDriver) Prepare() error {
 	common.HashFlag()
 	flag.BoolVar(&d.fixedLen, "format.protobuf.fixedlen", false, "Prefix the protobuf with message length")
+	flag.BoolVar(&d.convertToIPV6, "format.protobuf.toipv6", false, "Convert all addresses to IPV6 format on the wire")
 	return nil
 }
 
@@ -29,7 +34,14 @@ func (d *ProtobufDriver) Format(data interface{}) ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("message is not protobuf")
 	}
 	key := common.HashProtoLocal(msg)
+	if d.convertToIPV6 {
+		if fm, ok := msg.(*flowmessage.FlowMessage); !ok {
+			return nil, nil, fmt.Errorf("message is not a flowmessage")
+		} else {
+			convertAddressesToIPV6(fm)
+		}
 
+	}
 	if !d.fixedLen {
 		b, err := proto.Marshal(msg)
 		return []byte(key), b, err
@@ -43,4 +55,12 @@ func (d *ProtobufDriver) Format(data interface{}) ([]byte, []byte, error) {
 func init() {
 	d := &ProtobufDriver{}
 	format.RegisterFormatDriver("pb", d)
+}
+
+func convertAddressesToIPV6(flowMessage *flowmessage.FlowMessage) {
+	flowMessage.SrcAddr = net.IP(flowMessage.SrcAddr).To16()
+	flowMessage.DstAddr = net.IP(flowMessage.DstAddr).To16()
+	flowMessage.NextHop = net.IP(flowMessage.NextHop).To16()
+	flowMessage.SamplerAddress = net.IP(flowMessage.SamplerAddress).To16()
+	flowMessage.BgpNextHop = net.IP(flowMessage.BgpNextHop).To16()
 }


### PR DESCRIPTION
Clickhouse does not play nicely with ipv4 addresses in FixedString(16) column types.  In order to store ipv6 and ipv4 data in the same column, we must convert ipv4 addresses to their ipv6 representation.  This new option for protobuf allows for this conversion.