### PR TITLE
Auto build enricher in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY . /build
 WORKDIR /build
 
 RUN go build -ldflags "${LDFLAGS}" -o goflow2 cmd/goflow2/main.go
+RUN go build -ldflags "${LDFLAGS}" -o enricher cmd/enricher/main.go
 
 FROM alpine:latest
 ARG src_dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ LABEL org.opencontainers.image.revision="${REV}"
 RUN apk update --no-cache && \
     adduser -S -D -H -h / flow
 USER flow
-COPY --from=builder /build/goflow2 /
+COPY --from=builder /build/goflow2 /build/enricher /
 
 ENTRYPOINT ["./goflow2"]


### PR DESCRIPTION
This pull request updates the `Dockerfile` to build the enricher for folks that would like to use it inside of a Docker container. Feel free to close this pull request if this is too much bloat to the Docker image, but I found this useful to fork and push an image for and thought others might as well.

This won't affect any of the runtime in the container unless someone changes the `command`.