### PR TITLE
producer: fix sFlow parsing when sampled header is truncated

### DIFF
--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -1,10 +1,13 @@
 package producer
 
 import (
+	"encoding/binary"
+	"net"
 	"testing"
 
 	"github.com/netsampler/goflow2/decoders/netflow"
 	"github.com/netsampler/goflow2/decoders/sflow"
+	flowmessage "github.com/netsampler/goflow2/pb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,8 +76,26 @@ func TestProcessMessageSFlow(t *testing.T) {
 			},
 		},
 	}
-	_, err := ProcessMessageSFlow(pkt)
+	flowMessages, err := ProcessMessageSFlow(pkt)
 	assert.Nil(t, err)
+	assert.Equal(t, flowMessages[0], &flowmessage.FlowMessage{
+		Type:          flowmessage.FlowMessage_SFLOW_5,
+		SamplingRate:  1,
+		Bytes:         10,
+		Packets:       1,
+		SrcAddr:       net.ParseIP("fd01::ff01:8210:cdff:ff1c:0:150"),
+		DstAddr:       net.ParseIP("fd01::ff01:1:2ff:ff93:0:246"),
+		Etype:         0x86dd,
+		Proto:         6,
+		SrcPort:       53194,
+		DstPort:       80,
+		SrcMac:        binary.BigEndian.Uint64([]byte{0, 0, 0xff, 0xab, 0xcd, 0xef, 0xab, 0xbc}),
+		DstMac:        binary.BigEndian.Uint64([]byte{0, 0, 0xff, 0xab, 0xcd, 0xef, 0xab, 0xcd}),
+		IpTos:         2,
+		IpTtl:         64,
+		TcpFlags:      24,
+		Ipv6FlowLabel: 967916,
+	})
 }
 
 func TestExpandedSFlowDecode(t *testing.T) {


### PR DESCRIPTION
We return early if we don't even have an Ethernet header. We also need to increment the offset even if data is truncated to not confuse the remaining of the packet with something else (eg extract TCP/UDP ports when TCP/UDP header is too short).

Use IHL to correctly skip the IPv4 header when there are IP options. Also fix the offset for TCP payload.

This also removes the encap/iteration loop. As encap is set to false at the beginning of the loop, it was always executed one. I suppose this was the remaining of some other code. The `iterateMpls` flag is removed by moving some code around. One should look the diff with blanks ignored.

Unfortunately, not everything is covered by tests, notably MPLS parsing. Please double check this part.

Also, unrelated, but I wonder why you use `(*flowMessage).SrcAddr` instead of just `flowMessage.SrcAddr`. 