### PR TITLE
templates: don't make missing template a fatal error

### DIFF
--- a/decoders/sflow/sflow.go
+++ b/decoders/sflow/sflow.go
@@ -366,20 +366,20 @@ func DecodeMessage(payload *bytes.Buffer) (interface{}, error) {
 		packetV5.Version = version
 		err = utils.BinaryDecoder(payload, &(packetV5.IPVersion))
 		if err != nil {
-			return packetV5, err
+			return nil, err
 		}
 		var ip []byte
 		if packetV5.IPVersion == 1 {
 			ip = make([]byte, 4)
 			err = utils.BinaryDecoder(payload, ip)
 			if err != nil {
-				return packetV5, err
+				return nil, err
 			}
 		} else if packetV5.IPVersion == 2 {
 			ip = make([]byte, 16)
 			err = utils.BinaryDecoder(payload, ip)
 			if err != nil {
-				return packetV5, err
+				return nil, err
 			}
 		} else {
 			return nil, NewErrorIPVersion(packetV5.IPVersion)
@@ -388,14 +388,14 @@ func DecodeMessage(payload *bytes.Buffer) (interface{}, error) {
 		packetV5.AgentIP = ip
 		err = utils.BinaryDecoder(payload, &(packetV5.SubAgentId), &(packetV5.SequenceNumber), &(packetV5.Uptime), &(packetV5.SamplesCount))
 		if err != nil {
-			return packetV5, err
+			return nil, err
 		}
 		packetV5.Samples = make([]interface{}, int(packetV5.SamplesCount))
 		for i := 0; i < int(packetV5.SamplesCount) && payload.Len() >= 8; i++ {
 			header := SampleHeader{}
 			err = utils.BinaryDecoder(payload, &(header.Format), &(header.Length))
 			if err != nil {
-				return packetV5, err
+				return nil, err
 			}
 			if int(header.Length) > payload.Len() {
 				break


### PR DESCRIPTION
Notably, a packet could contain data, template, data, template and when this is the case, the template will never be parsed.

There is also a slight API change: we return data and error only for non-fatal errors (missing template) and not for other errors (where we return nil and error). This still leaves a chance for the user to report the missing templates and this is less confusing as when we can get both data and error and when not.

sflow decoder is also modified with the same logic (return nil and error instead of data and error since all errors should be considered fatal).

See https://github.com/akvorado/akvorado/issues/697