### PR TITLE
decoders: fix netflow legacy/v5 sampling interval

### DIFF
--- a/decoders/netflowlegacy/netflow.go
+++ b/decoders/netflowlegacy/netflow.go
@@ -39,7 +39,7 @@ func DecodeMessage(payload *bytes.Buffer) (interface{}, error) {
 			&(packet.FlowSequence),
 			&(packet.EngineType),
 			&(packet.EngineId),
-			&(packet.SamplingInterval),
+			&(packet.SamplingInterval & 0x3FFF),
 		)
 
 		packet.Records = make([]RecordsNetFlowV5, int(packet.Count))


### PR DESCRIPTION
Filter out the sampling mode (first two bits) and keep the sampling rate.

Closes #167