### PR TITLE
producer: bugfix of sampling mapping for ipfix

### DIFF
--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -182,7 +182,7 @@ func GetTemplateSize(version uint16, template []Field) int {
 
 func DecodeDataSetUsingFields(version uint16, payload *bytes.Buffer, listFields []Field) ([]DataField, error) {
 	dataFields := make([]DataField, len(listFields))
-	for payload.Len() >= GetTemplateSize(version, listFields) {
+	if payload.Len() >= GetTemplateSize(version, listFields) {
 
 		for i, templateField := range listFields {
 

--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -3,7 +3,6 @@ package protoproducer
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -47,19 +46,11 @@ func (s *basicSamplingRateSystem) AddSamplingRate(version uint16, obsDomainId ui
 func (s *basicSamplingRateSystem) GetSamplingRate(version uint16, obsDomainId uint32) (uint32, error) {
 	s.samplinglock.RLock()
 	defer s.samplinglock.RUnlock()
-	/*samplingVersion, okver := s.sampling[version]
-	if okver {
-		samplingRate, okid := samplingVersion[obsDomainId]
-		if okid {
-			return samplingRate, nil
-		}
-		return 0, errors.New("") // TBC
-	}*/
 	if samplingRate, ok := s.sampling[fmt.Sprintf("%d-%d", version, obsDomainId)]; ok {
 		return samplingRate, nil
 	}
 
-	return 0, errors.New("") // TBC // todo: now
+	return 0, fmt.Errorf("sampling rate not found")
 }
 
 type SingleSamplingRateSystem struct {

--- a/producer/proto/proto.go
+++ b/producer/proto/proto.go
@@ -28,7 +28,7 @@ func (p *ProtoProducer) enrich(flowMessageSet []producer.ProducerMessage, cb fun
 }
 
 func (p *ProtoProducer) getSamplingRateSystem(args *producer.ProduceArgs) SamplingRateSystem {
-	key := args.Src.String()
+	key := args.Src.Addr().String()
 	p.samplinglock.RLock()
 	sampling, ok := p.sampling[key]
 	p.samplinglock.RUnlock()


### PR DESCRIPTION
Fixes #206 

The sampling rate was not properly added to IPFIX/NetFlow v9 produced packets.
Two issues were present in the code:
* The actual field in the options was ignored due to a `for` loop consuming all the data.
* The samplingsystem containing the sampling rates of a specific router had a key that listed the port, while some samplers send on a different port the option templates causing the option data being separated from the sample data.