### PR TITLE
Add workers, isBlocking and queue size to listen config

### DIFF
--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -193,6 +193,36 @@ func main() {
 			numSockets = 1
 		}
 
+		numWorkers := 0
+		if listenAddrUrl.Query().Has("workers") {
+			if numWorkersTmp, err := strconv.ParseUint(listenAddrUrl.Query().Get("workers"), 10, 64); err != nil {
+				log.Fatal(err)
+			} else {
+				numWorkers = int(numWorkersTmp)
+			}
+		}
+		if numWorkers == 0 {
+			numWorkers = numSockets * 2
+		}
+
+		isBlocking := false
+		if listenAddrUrl.Query().Has("blocking") {
+			if isBlocking, err = strconv.ParseBool(listenAddrUrl.Query().Get("blocking")); err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		queueSize := 0
+		if listenAddrUrl.Query().Has("queue_size") {
+			if queueSizeTmp, err := strconv.ParseUint(listenAddrUrl.Query().Get("queue_size"), 10, 64); err != nil {
+				log.Fatal(err)
+			} else {
+				queueSize = int(queueSizeTmp)
+			}
+		} else if !isBlocking {
+			queueSize = 1000000
+		}
+
 		hostname := listenAddrUrl.Hostname()
 		port, err := strconv.ParseUint(listenAddrUrl.Port(), 10, 64)
 		if err != nil {
@@ -201,17 +231,23 @@ func main() {
 		}
 
 		logFields := log.Fields{
-			"scheme":   listenAddrUrl.Scheme,
-			"hostname": hostname,
-			"port":     port,
-			"count":    numSockets,
+			"scheme":     listenAddrUrl.Scheme,
+			"hostname":   hostname,
+			"port":       port,
+			"count":      numSockets,
+			"workers":    numWorkers,
+			"blocking":   isBlocking,
+			"queue_size": queueSize,
 		}
 		l := log.WithFields(logFields)
 
 		l.Info("starting collection")
 
 		cfg := &utils.UDPReceiverConfig{
-			Sockets: numSockets,
+			Sockets:   numSockets,
+			Workers:   numWorkers,
+			QueueSize: queueSize,
+			Blocking:  isBlocking,
 		}
 		recv, err := utils.NewUDPReceiver(cfg)
 		if err != nil {

--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -193,7 +193,7 @@ func main() {
 			numSockets = 1
 		}
 
-		numWorkers := 0
+		var numWorkers int
 		if listenAddrUrl.Query().Has("workers") {
 			if numWorkersTmp, err := strconv.ParseUint(listenAddrUrl.Query().Get("workers"), 10, 64); err != nil {
 				log.Fatal(err)
@@ -205,14 +205,14 @@ func main() {
 			numWorkers = numSockets * 2
 		}
 
-		isBlocking := false
+		var isBlocking bool
 		if listenAddrUrl.Query().Has("blocking") {
 			if isBlocking, err = strconv.ParseBool(listenAddrUrl.Query().Get("blocking")); err != nil {
 				log.Fatal(err)
 			}
 		}
 
-		queueSize := 0
+		var queueSize int
 		if listenAddrUrl.Query().Has("queue_size") {
 			if queueSizeTmp, err := strconv.ParseUint(listenAddrUrl.Query().Get("queue_size"), 10, 64); err != nil {
 				log.Fatal(err)

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -73,7 +73,7 @@ func NewUDPReceiver(cfg *UDPReceiverConfig) (*UDPReceiver, error) {
 		}
 
 		if cfg.Workers <= 0 {
-			cfg.Workers = cfg.Sockets
+			cfg.Workers = cfg.Sockets * 2
 		}
 
 		r.sockets = cfg.Sockets

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -73,7 +73,7 @@ func NewUDPReceiver(cfg *UDPReceiverConfig) (*UDPReceiver, error) {
 		}
 
 		if cfg.Workers <= 0 {
-			cfg.Workers = cfg.Sockets * 2
+			cfg.Workers = cfg.Sockets
 		}
 
 		r.sockets = cfg.Sockets


### PR DESCRIPTION
I was testing flows collecting from pmacct and goflow2 and realized that goflow2 is loosing packets (goflow2 should have MORE data, because pmacct is aggregating in memory and flush aggregated)

```sql
SELECT *
FROM collector_compare

Query id: 4d8b440f-06ff-4ff8-b732-8292b5b16b44

┌─type───────┬─pmacct_count────┬─goflow_count────┬─diff───────────┬─percent─┐
│ IPFIX      │ 199.16 thousand │ 190.66 thousand │ -8.50 thousand │ -4.3%   │
│ SFLOW_5    │ 33.23 million   │ 24.47 million   │ -8.75 million  │ -26.3%  │
│ NETFLOW_V5 │ 202.00          │ 203.00          │ 1.00           │ 0.5%    │
└────────────┴─────────────────┴─────────────────┴────────────────┴─────────┘
```

After debugging I realized that when we have `1 socket = 1 worker` -> with high volume of flows per second reading packet will be faster than processing (and dispatch channel will be growing), so I propose:

1. Add config options to listening url with handling defaults (if blocking=0 queue=1000000 else queue=0 , and numWorkers = sockets*2)
2. In `udp.go` increase default workers count to `cfg.Sockets * 2`

After changes:

```sql
┌─type───────┬─pmacct_count───┬─goflow_count───┬─diff───────────┬─percent─┐
│ IPFIX      │ 10.16 million  │ 10.16 million  │ 274.00         │ 0%      │
│ SFLOW_5    │ 345.81 million │ 484.31 million │ 138.50 million │ 28.6%   │
│ NETFLOW_V5 │ 9.21 thousand  │ 9.20 thousand  │ -7.00          │ -0.1%   │
└────────────┴────────────────┴────────────────┴────────────────┴─────────┘
```