### PR TITLE
fix: missing time received ns in netflow v5

### DIFF
--- a/producer/proto/proto.go
+++ b/producer/proto/proto.go
@@ -50,6 +50,7 @@ func (p *ProtoProducer) Produce(msg interface{}, args *producer.ProduceArgs) (fl
 		flowMessageSet, err = ProcessMessageNetFlowLegacy(msgConv)
 
 		p.enrich(flowMessageSet, func(fmsg *ProtoProducerMessage) {
+			fmsg.TimeReceivedNs = tr
 			fmsg.SamplerAddress = sa
 		})
 	case *netflow.NFv9Packet:


### PR DESCRIPTION
Missing TimeReceivedNs value in netflow v5.

Before and after:
![image](https://github.com/netsampler/goflow2/assets/3045505/78c22f79-8bd6-4527-8c1d-027e53555a0a)
