### PR TITLE
producer: fix fragment

### DIFF
--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -99,7 +99,7 @@ func ParseIPv4(offset int, flowMessage *ProtoProducerMessage, data []byte) (next
 		fragOffset := binary.BigEndian.Uint16(data[offset+6 : offset+8]) // also includes flag
 
 		flowMessage.FragmentId = uint32(identification)
-		flowMessage.FragmentOffset = uint32(fragOffset) & 57344
+		flowMessage.FragmentOffset = uint32(fragOffset) & 8191
 		flowMessage.IpFlags = uint32(fragOffset) >> 13
 
 		offset += 20

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -260,5 +260,5 @@ func TestProcessIPv4Fragment(t *testing.T) {
 	assert.Equal(t, uint32(0), flowMessage.IpFlags)
 	assert.Equal(t, uint32(64), flowMessage.IpTtl)
 	assert.Equal(t, uint32(24025), flowMessage.FragmentId)
-	assert.Equal(t, uint32(0), flowMessage.FragmentOffset)
+	assert.Equal(t, uint32(185), flowMessage.FragmentOffset)
 }


### PR DESCRIPTION
I introduced a bug in #213 and used `0xE000` instead of `0x1FFF`