### PR TITLE
producer: fix fragment for NetFlow

### DIFF
--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -491,7 +491,7 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 			if err := DecodeUNumber(v, &ipFlags); err != nil {
 				return err
 			}
-			flowMessage.IpFlags = ipFlags
+			flowMessage.IpFlags = ipFlags >> 5
 		case netflow.NFV9_FIELD_IPV6_FLOW_LABEL:
 			if err := DecodeUNumber(v, &(flowMessage.Ipv6FlowLabel)); err != nil {
 				return err


### PR DESCRIPTION
Per https://www.iana.org/assignments/ipfix/ipfix.xhtml

```
Bit 0:    (RS) Reserved.
          The value of this bit MUST be 0 until specified
          otherwise.

Bit 1:    (DF) 0 = May Fragment,  1 = Don't Fragment.
          Corresponds to the value of the DF flag in the
          IPv4 header.  Will always be 0 for IPv6 unless
          a "don't fragment" feature is introduced to IPv6.

Bit 2:    (MF) 0 = Last Fragment, 1 = More Fragments.
          Corresponds to the MF flag in the IPv4 header
          or to the M flag in the IPv6 Fragment header,
          respectively.  The value is 0 for IPv6 if there
          is no fragment header.

Bits 3-7: (DC) Don't Care.
          The values of these bits are irrelevant.

     0   1   2   3   4   5   6   7
   +---+---+---+---+---+---+---+---+
   | R | D | M | D | D | D | D | D |
   | S | F | F | C | C | C | C | C |
   +---+---+---+---+---+---+---+---+
```

Which differs from the sFlow implementation.


https://github.com/netsampler/goflow2/blob/edc306cc2983febb33b474e491e9568db603e13d/producer/proto/producer_sf.go#L103

https://github.com/netsampler/goflow2/blob/edc306cc2983febb33b474e491e9568db603e13d/producer/proto/producer_sf.go#L141
