### PR TITLE
add metrics for udp received/dropped/error

### DIFF
--- a/utils/udp.go
+++ b/utils/udp.go
@@ -25,14 +25,6 @@ var (
 		},
 		[]string{"addr", "port"},
 	)
-	MetricUdpPacketReceived = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name:      "udp_packets_received",
-			Help:      "UDP Packets received",
-			Namespace: NAMESPACE,
-		},
-		[]string{"addr", "port"},
-	)
 	MetricUdpPacketError = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name:      "udp_packets_error",
@@ -53,7 +45,6 @@ var (
 
 func init() {
 	prometheus.MustRegister(MetricUdpPacketDropped)
-	prometheus.MustRegister(MetricUdpPacketReceived)
 	prometheus.MustRegister(MetricUdpPacketError)
 	prometheus.MustRegister(MetricUdpPacketInvalid)
 
@@ -222,24 +213,12 @@ func (r *UDPReceiver) receive(addr string, port int, started chan bool) error {
 			// if combined with synchronous mode
 			select {
 			case r.dispatch <- pkt:
-				MetricUdpPacketReceived.With(
-					prometheus.Labels{
-						"addr": addr,
-						"port": strconv.Itoa(port),
-					},
-				).Inc()
 			case <-r.q:
 				return nil
 			}
 		} else {
 			select {
 			case r.dispatch <- pkt:
-				MetricUdpPacketReceived.With(
-					prometheus.Labels{
-						"addr": addr,
-						"port": strconv.Itoa(port),
-					},
-				).Inc()
 			case <-r.q:
 				return nil
 			default:

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -19,7 +19,7 @@ const (
 var (
 	MetricUdpPacketDropped = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:      "udp_packets_dropped",
+			Name:      "udp_packets_dropped_total",
 			Help:      "UDP Packets dropped",
 			Namespace: NAMESPACE,
 		},
@@ -27,7 +27,7 @@ var (
 	)
 	MetricUdpPacketError = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:      "udp_packets_error",
+			Name:      "udp_packets_error_total",
 			Help:      "UDP Packets error",
 			Namespace: NAMESPACE,
 		},
@@ -35,7 +35,7 @@ var (
 	)
 	MetricUdpPacketInvalid = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:      "udp_packets_invalid",
+			Name:      "udp_packets_invalid_total",
 			Help:      "UDP Packets invalid",
 			Namespace: NAMESPACE,
 		},

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -47,7 +47,6 @@ func init() {
 	prometheus.MustRegister(MetricUdpPacketDropped)
 	prometheus.MustRegister(MetricUdpPacketError)
 	prometheus.MustRegister(MetricUdpPacketInvalid)
-
 }
 
 // Callback used to decode a UDP message


### PR DESCRIPTION
I've added metrics for receiving packets:
1. Received
2. Dropped (important for our anty-ddos project)
3. Invalid & error

This is easy version - just registering metrics in udp.go.
Alternative: separate metrics from metrics/metrics.go to package, because in metrics/decoder.go there is import for "utils" pkg, so in utils we can't use metrics. And I don't know if this is preferred.

![image](https://github.com/netsampler/goflow2/assets/3045505/22ea56f4-97a6-481f-a55f-eccc448e8002)
