### PR TITLE
producer: add datetime render

### DIFF
--- a/cmd/goflow2/mapping.yaml
+++ b/cmd/goflow2/mapping.yaml
@@ -43,6 +43,8 @@ formatter:
     - name: csum
       index: 999
       type: varint
+  render:
+    time_received_ns: datetimenano
 # Decoder mappings
 ipfix:
   mapping:

--- a/producer/proto/render.go
+++ b/producer/proto/render.go
@@ -102,6 +102,12 @@ func DateTimeRenderer(msg *ProtoProducerMessage, fieldName string, data interfac
 	} else if dataC, ok := data.(int64); ok {
 		ts := time.Unix(dataC, 0).UTC()
 		return ts.Format(time.RFC3339Nano)
+	} else if dataC, ok := data.(uint32); ok {
+		ts := time.Unix(int64(dataC), 0).UTC()
+		return ts.Format(time.RFC3339Nano)
+	} else if dataC, ok := data.(int32); ok {
+		ts := time.Unix(int64(dataC), 0).UTC()
+		return ts.Format(time.RFC3339Nano)
 	}
 	return NilRenderer(msg, fieldName, data)
 }


### PR DESCRIPTION
When using a custom configuration, integers can be represented as a RFC3339 string.