### PR TITLE
producer: support custom mapping of ipip

### DIFF
--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -352,9 +352,6 @@ func ParseEthernetHeader(flowMessage *ProtoProducerMessage, data []byte, config 
 						}
 					}
 				} else if nextHeader == 4 { // IPIP
-					if offset, err = ParseICMPv6(offset, flowMessage, data); err != nil {
-						return err
-					}
 					for _, configLayer := range GetSFlowConfigLayer(config, "ipip") {
 						extracted := GetBytes(data, prevOffset*8+configLayer.Offset, configLayer.Length)
 						if err := MapCustom(flowMessage, extracted, configLayer.MapConfigBase); err != nil {

--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -308,7 +308,7 @@ func ParseEthernetHeader(flowMessage *ProtoProducerMessage, data []byte, config 
 		var appOffset int // keeps track of the user payload
 
 		// Transport protocols
-		if nextHeader == 17 || nextHeader == 6 || nextHeader == 1 || nextHeader == 58 {
+		if nextHeader == 17 || nextHeader == 6 || nextHeader == 1 || nextHeader == 58 || nextHeader == 4 {
 			prevOffset := offset
 			if flowMessage.FragmentOffset == 0 {
 				if nextHeader == 17 { // UDP

--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -351,6 +351,16 @@ func ParseEthernetHeader(flowMessage *ProtoProducerMessage, data []byte, config 
 							return err
 						}
 					}
+				} else if nextHeader == 4 { // IPIP
+					if offset, err = ParseICMPv6(offset, flowMessage, data); err != nil {
+						return err
+					}
+					for _, configLayer := range GetSFlowConfigLayer(config, "ipip") {
+						extracted := GetBytes(data, prevOffset*8+configLayer.Offset, configLayer.Length)
+						if err := MapCustom(flowMessage, extracted, configLayer.MapConfigBase); err != nil {
+							return err
+						}
+					}
 				}
 			}
 			appOffset = offset


### PR DESCRIPTION
Provides the possibility to decode inside an IPIP packet.
Not a great change since any TCP/UDP inside this IPIP will be ignored.