### PR TITLE
decoders: do not stop reading sets

### DIFF
--- a/decoders/netflow/ipfix.go
+++ b/decoders/netflow/ipfix.go
@@ -977,6 +977,9 @@ func (p IPFIXPacket) String() string {
 		case DataFlowSet:
 			str += fmt.Sprintf("    - DataFlowSet %v:\n", i)
 			str += flowSet.String(IPFIXTypeToString)
+		case RawFlowSet:
+			str += fmt.Sprintf("    - RawFlowSet %v:\n", i)
+			str += flowSet.String()
 		case OptionsDataFlowSet:
 			str += fmt.Sprintf("    - OptionsDataFlowSet %v:\n", i)
 			str += flowSet.String(IPFIXTypeToString, IPFIXTypeToString)

--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -393,7 +393,12 @@ func DecodeMessageCommonFlowSet(payload *bytes.Buffer, templates NetFlowTemplate
 		}
 
 	} else if fsheader.Id >= 256 {
-		dataReader := bytes.NewBuffer(payload.Next(nextrelpos))
+		rawfs := RawFlowSet{
+			FlowSetHeader: fsheader,
+			Records:       payload.Next(nextrelpos),
+		}
+		flowSet = rawfs
+		dataReader := bytes.NewBuffer(rawfs.Records)
 
 		if templates == nil {
 			return flowSet, &FlowError{version, "Templates", obsDomainId, fsheader.Id, fmt.Errorf("No templates")}

--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -284,7 +284,6 @@ func DecodeDataSet(version uint16, payload *bytes.Buffer, listFields []Field) ([
 }
 
 func DecodeMessageCommon(payload *bytes.Buffer, templates NetFlowTemplateSystem, obsDomainId uint32, size, version uint16) (flowSets []interface{}, err error) {
-func DecodeMessageCommon(payload *bytes.Buffer, templates NetFlowTemplateSystem, obsDomainId uint32, size, version uint16) (flowSets []interface{}, err error) {
 	var read int
 	startSize := payload.Len()
 	for i := 0; ((i < int(size) && version == 9) || (uint16(read) < size && version == 10)) && payload.Len() > 0; i++ {

--- a/decoders/netflow/nfv9.go
+++ b/decoders/netflow/nfv9.go
@@ -306,6 +306,9 @@ func (p NFv9Packet) String() string {
 		case DataFlowSet:
 			str += fmt.Sprintf("    - DataFlowSet %v:\n", i)
 			str += flowSet.String(NFv9TypeToString)
+		case RawFlowSet:
+			str += fmt.Sprintf("    - RawFlowSet %v:\n", i)
+			str += flowSet.String()
 		case OptionsDataFlowSet:
 			str += fmt.Sprintf("    - OptionsDataFlowSet %v:\n", i)
 			str += flowSet.String(NFv9TypeToString, NFv9ScopeToString)

--- a/decoders/netflow/packet.go
+++ b/decoders/netflow/packet.go
@@ -34,6 +34,13 @@ type DataFlowSet struct {
 	Records []DataRecord `json:"records"`
 }
 
+// RawFlowSet is a a set that could not be decoded due to the absence of a template
+type RawFlowSet struct {
+	FlowSetHeader
+
+	Records []byte `json:"records"`
+}
+
 type OptionsDataFlowSet struct {
 	FlowSetHeader
 
@@ -96,6 +103,14 @@ type DataField struct {
 	// The value (in bytes) of the field.
 	Value interface{} `json:"value"`
 	//Value []byte
+}
+
+func (flowSet RawFlowSet) String() string {
+	str := fmt.Sprintf("       Id %v\n", flowSet.Id)
+	str += fmt.Sprintf("       Length: %v\n", len(flowSet.Records))
+	str += fmt.Sprintf("       Records: %v\n", flowSet.Records)
+
+	return str
 }
 
 func (flowSet OptionsDataFlowSet) String(TypeToString func(uint16) string, ScopeToString func(uint16) string) string {


### PR DESCRIPTION
If a packet has multiple sets, keep reading, accumulate errors instead of stopping at the first template not found