### PR TITLE
compose: fix kcg dashboard query

### DIFF
--- a/compose/kcg/grafana/dashboards/viz-ch.json
+++ b/compose/kcg/grafana/dashboards/viz-ch.json
@@ -78,6 +78,7 @@
           "intervalFactor": 1,
           "metricColumn": "none",
           "query": "SELECT\n    t,\n    sum(sumbytes) AS sumbytes\nFROM (\n    SELECT\n        $timeSeries AS t,\n        sum(bytes*sampling_rate) as sumbytes\n    FROM $table\n    WHERE $timeFilter\n    GROUP BY t\n\n    UNION ALL\n\n    SELECT\n        toInt64(intDiv($from+number*$interval, $interval)*$interval*1000) AS t,\n        0 AS sumbytes\n    FROM numbers(intDiv($to-$from, $interval))\n)\nGROUP BY t\nORDER BY t",
+          "refId": "A",
           "round": "0s",
           "select": [
             [

--- a/compose/kcg/grafana/dashboards/viz-ch.json
+++ b/compose/kcg/grafana/dashboards/viz-ch.json
@@ -77,7 +77,7 @@
           "group": [],
           "intervalFactor": 1,
           "metricColumn": "none",
-          "query": "SELECT\n    t,\n    sum(sumbytes) AS sumbytes\nFROM (\n    SELECT\n        $timeSeries AS t,\n        sum(bytes*sampling_rate) as sumbytes\n    FROM $table\n    WHERE $timeFilter\n    GROUP BY t\n\n    UNION ALL\n\n    SELECT\n        intDiv($from+number*$interval, $interval)*$interval*1000 AS t,\n        0 AS sumbytes\n    FROM numbers(intDiv($to-$from, $interval))\n)\nGROUP BY t\nORDER BY t",          "refId": "A",
+          "query": "SELECT\n    t,\n    sum(sumbytes) AS sumbytes\nFROM (\n    SELECT\n        $timeSeries AS t,\n        sum(bytes*sampling_rate) as sumbytes\n    FROM $table\n    WHERE $timeFilter\n    GROUP BY t\n\n    UNION ALL\n\n    SELECT\n        toInt64(intDiv($from+number*$interval, $interval)*$interval*1000) AS t,\n        0 AS sumbytes\n    FROM numbers(intDiv($to-$from, $interval))\n)\nGROUP BY t\nORDER BY t",
           "round": "0s",
           "select": [
             [


### PR DESCRIPTION
Addresses #240.

A recent ClickHouse update likely changed the `intDiv` function that is used in the union with numbers. One column was `UInt64`, the other was `Int64` causing an error.