### PR TITLE
transport: mute errors when too verbose

### DIFF
--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -287,6 +287,8 @@ func main() {
 		decodeFunc = metrics.PromDecoderWrapper(decodeFunc, listenAddrUrl.Scheme)
 		pipes = append(pipes, p)
 
+		bm := utils.NewBatchMute(*ErrInt, *ErrCnt)
+
 		// starts receivers
 		// the function either returns an error
 		if err := recv.Start(hostname, int(port), decodeFunc); err != nil {
@@ -301,22 +303,33 @@ func main() {
 					case <-q:
 						return
 					case err := <-recv.Errors():
-						l := l.WithError(err)
-						if errors.Is(err, netflow.ErrorTemplateNotFound) {
-							l.Warn("template error")
-						} else if errors.Is(err, debug.PanicError) {
-							var pErrMsg *debug.PanicErrorMessage
-							if errors.As(err, &pErrMsg) {
-								l = l.WithFields(log.Fields{
-									"message":    pErrMsg.Msg,
-									"stacktrace": string(pErrMsg.Stacktrace),
-								})
-							}
-							l.Error("intercepted panic")
-						} else if errors.Is(err, net.ErrClosed) {
+						if errors.Is(err, net.ErrClosed) {
 							l.Info("closed receiver")
-						} else {
+							continue
+						} else if !errors.Is(err, netflow.ErrorTemplateNotFound) && !errors.Is(err, debug.PanicError) {
 							l.Error("error")
+							continue
+						}
+
+						muted, skipped := bm.Increment()
+						if muted && skipped == 0 {
+							log.Warn("too many receiver messages, muting")
+						} else if !muted && skipped > 0 {
+							log.Warnf("skipped %d receiver messages", skipped)
+						} else if !muted {
+							l := l.WithError(err)
+							if errors.Is(err, netflow.ErrorTemplateNotFound) {
+								l.Warn("template error")
+							} else if errors.Is(err, debug.PanicError) {
+								var pErrMsg *debug.PanicErrorMessage
+								if errors.As(err, &pErrMsg) {
+									l = l.WithFields(log.Fields{
+										"message":    pErrMsg.Msg,
+										"stacktrace": string(pErrMsg.Stacktrace),
+									})
+								}
+								l.Error("intercepted panic")
+							}
 						}
 
 					}

--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -60,8 +60,8 @@ var (
 	Format    = flag.String("format", "json", fmt.Sprintf("Choose the format (available: %s)", strings.Join(format.GetFormats(), ", ")))
 	Transport = flag.String("transport", "file", fmt.Sprintf("Choose the transport (available: %s)", strings.Join(transport.GetTransports(), ", ")))
 
-	TransportErrCt  = flag.Int("transport.err", 10, "Maximum transport errors per batch")
-	TransportErrInt = flag.Duration("transport.int", time.Second*10, "Maximum transport errors interval")
+	TransportErrCt  = flag.Int("transport.err.cnt", 10, "Maximum transport errors per batch")
+	TransportErrInt = flag.Duration("transport.err.int", time.Second*10, "Maximum transport errors interval")
 
 	Addr = flag.String("addr", ":8080", "HTTP server address")
 

--- a/utils/mute.go
+++ b/utils/mute.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"time"
+)
+
+type BatchMute struct {
+	batchTime     time.Time
+	resetInterval time.Duration
+	ctr           int
+	max           int
+}
+
+func (b *BatchMute) increment(val int, t time.Time) (muted bool, skipped int) {
+
+	if b.max == 0 || b.resetInterval == 0 {
+		return muted, skipped
+	}
+
+	if b.ctr >= b.max {
+		skipped = b.ctr - b.max
+	}
+
+	if t.Sub(b.batchTime) > b.resetInterval {
+		b.ctr = 0
+		b.batchTime = t
+	}
+	b.ctr += val
+
+	return b.max > 0 && b.ctr > b.max, skipped
+}
+
+func (b *BatchMute) Increment() (muting bool, skipped int) {
+	return b.increment(1, time.Now().UTC())
+}
+
+func NewBatchMute(resetInterval time.Duration, max int) *BatchMute {
+	return &BatchMute{
+		batchTime:     time.Now().UTC(),
+		resetInterval: resetInterval,
+		max:           max,
+	}
+}

--- a/utils/mute_test.go
+++ b/utils/mute_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBatchMute(t *testing.T) {
+	tm := time.Date(2023, time.November, 10, 23, 0, 0, 0, time.UTC)
+	bm := BatchMute{
+		batchTime:     tm,
+		resetInterval: time.Second * 10,
+		max:           5,
+	}
+
+	for i := 0; i < 20; i++ {
+		tm = tm.Add(time.Second)
+		t.Log(bm.increment(1, tm))
+	}
+
+}
+
+func TestBatchMuteZero(t *testing.T) {
+	tm := time.Date(2023, time.November, 10, 23, 0, 0, 0, time.UTC)
+	bm := BatchMute{
+		batchTime:     tm,
+		resetInterval: time.Second * 10,
+		max:           0,
+	}
+
+	for i := 0; i < 20; i++ {
+		tm = tm.Add(time.Second)
+		t.Log(bm.increment(1, tm))
+	}
+
+}
+
+func TestBatchMuteInterval(t *testing.T) {
+	tm := time.Date(2023, time.November, 10, 23, 0, 0, 0, time.UTC)
+	bm := BatchMute{
+		batchTime:     tm,
+		resetInterval: 0,
+		max:           5,
+	}
+
+	for i := 0; i < 20; i++ {
+		tm = tm.Add(time.Second)
+		t.Log(bm.increment(1, tm))
+	}
+
+}


### PR DESCRIPTION
This adds two CLI arguments that will by default reduce the amount of logs if there is an issue (transport like kafka logs or decoder templates).

Arguments:
* `err.int`: interval to log errors
* `err.cnt`: threshold of errors per interval

If the threshold of errors during an interval is crossed, subsequent errors will be muted until the interval clears.

One of the common case is when Kafka is down:

```
ERRO[0043] transport error                               error="kafka transport kafka: Failed to produce message to topic flow-messages: circuit breaker is open"
WARN[0043] too many transport errors, muting
WARN[0052] skipped 85 transport errors
ERRO[0052] transport error                               error="kafka transport kafka: Failed to produce message to topic flow-messages: circuit breaker is open"
ERRO[0052] transport error                               error="kafka transport kafka: Failed to produce message to topic flow-messages: circuit breaker is open"
ERRO[0052] transport error                               error="kafka transport kafka: Failed to produce message to topic flow-messages: circuit breaker is open"
```

Will require updating https://github.com/netsampler/goflow2/pull/199