### PR TITLE
format: fix renderer on v1

### DIFF
--- a/format/common/text.go
+++ b/format/common/text.go
@@ -186,7 +186,10 @@ func FormatMessageReflectCustom(msg interface{}, ext, quotes, sep, sign string, 
 		}
 		fieldValue := vfm.FieldByName(fieldName)
 		// todo: replace s by json mapping of protobuf
-		if fieldValue.IsValid() {
+		if renderer, ok := RenderExtras[fieldName]; ok {
+			fstr[i] = fmt.Sprintf("%s%s%s%s%q", quotes, s, quotes, sign, renderer(msg))
+			i++
+		} else if fieldValue.IsValid() {
 
 			if fieldType, ok := TextFields[fieldName]; ok {
 				switch fieldType {
@@ -213,8 +216,6 @@ func FormatMessageReflectCustom(msg interface{}, ext, quotes, sep, sign string, 
 
 					}
 				}
-			} else if renderer, ok := RenderExtras[fieldName]; ok {
-				fstr[i] = fmt.Sprintf("%s%s%s%s%q", quotes, s, quotes, sign, renderer(msg))
 			} else {
 				// handle specific types here
 				switch fieldValue.Kind() {


### PR DESCRIPTION
Addresses https://github.com/netsampler/goflow2/issues/245

Custom renderers (`EtypeName`...) were not used due to the name not being a field inside the protobuf.
This fixes by changing the condition and logic.