### PR TITLE
bugfix: check etype size before decoding

### DIFF
--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -390,7 +390,9 @@ func ParseEthernetHeader(flowMessage *ProtoProducerMessage, data []byte, config 
 		iterations++
 	}
 
-	flowMessage.Etype = uint32(binary.BigEndian.Uint16(etherType[0:2]))
+	if len(etherType) >= 2 {
+		flowMessage.Etype = uint32(binary.BigEndian.Uint16(etherType[0:2]))
+	}
 	flowMessage.Proto = uint32(nextHeader)
 
 	return nil

--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -238,6 +238,10 @@ func ParseEthernetHeader(flowMessage *ProtoProducerMessage, data []byte, config 
 		return err
 	}
 
+	if len(etherType) != 2 {
+		return nil
+	}
+
 	encap := true
 	iterations := 0
 	for encap && iterations <= 1 {

--- a/producer/proto/producer_sf.go
+++ b/producer/proto/producer_sf.go
@@ -200,22 +200,37 @@ func ParseICMPv6(offset int, flowMessage *ProtoProducerMessage, data []byte) (ne
 }
 
 func IsMPLS(etherType []byte) bool {
+	if len(etherType) != 2 {
+		return false
+	}
 	return etherType[0] == 0x88 && etherType[1] == 0x47
 }
 
 func Is8021Q(etherType []byte) bool {
+	if len(etherType) != 2 {
+		return false
+	}
 	return etherType[0] == 0x81 && etherType[1] == 0x0
 }
 
 func IsIPv4(etherType []byte) bool {
+	if len(etherType) != 2 {
+		return false
+	}
 	return etherType[0] == 0x8 && etherType[1] == 0x0
 }
 
 func IsIPv6(etherType []byte) bool {
+	if len(etherType) != 2 {
+		return false
+	}
 	return etherType[0] == 0x86 && etherType[1] == 0xdd
 }
 
 func IsARP(etherType []byte) bool {
+	if len(etherType) != 2 {
+		return false
+	}
 	return etherType[0] == 0x8 && etherType[1] == 0x6
 }
 


### PR DESCRIPTION
Closes #251

The `etherType` variable was not checked for length and could cause panic.