### PR TITLE
Add -logstream=[stdout|stderr] flag

### DIFF
--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -53,8 +53,9 @@ var (
 
 	ListenAddresses = flag.String("listen", "sflow://:6343,netflow://:2055", "listen addresses")
 
-	LogLevel = flag.String("loglevel", "info", "Log level")
-	LogFmt   = flag.String("logfmt", "normal", "Log formatter")
+	LogStream = flag.String("logstream", "stdout", "Log output stream (stdout or stderr)")
+	LogLevel  = flag.String("loglevel", "info", "Log level")
+	LogFmt    = flag.String("logfmt", "normal", "Log formatter")
 
 	Produce   = flag.String("produce", "sample", "Producer method (sample or raw)")
 	Format    = flag.String("format", "json", fmt.Sprintf("Choose the format (available: %s)", strings.Join(format.GetFormats(), ", ")))
@@ -86,6 +87,13 @@ func main() {
 
 	lvl, _ := log.ParseLevel(*LogLevel)
 	log.SetLevel(lvl)
+
+	switch *LogStream {
+	case "stdout":
+		log.SetOutput(os.Stdout)
+	case "stderr":
+		log.SetOutput(os.Stderr)
+	}
 
 	switch *LogFmt {
 	case "json":


### PR DESCRIPTION
It seems that GoFlow logs are always output to stdout, which makes it impractical to directly stream its output to another command. My use case being to have a very simple `goflow | database` pipeline for my homelab setup :-)

This adds a `-logstream` flag to change the log output stream to stderr instead.

Default / current behavior:
```
# go run cmd/goflow2/main.go 2> /dev/null
INFO[0000] starting GoFlow2                             
INFO[0000] starting collection  blocking=false count=1 hostname= port=6343 queue_size=1000000 scheme=sflow workers=2
INFO[0000] starting collection  blocking=false count=1 hostname= port=2055 queue_size=1000000 scheme=netflow workers=2
{"type":"IPFIX", ...}
{"type":"IPFIX", ...}
{"type":"IPFIX", ...}
```

With `-logstream=stderr`:
```
# go run cmd/goflow2/main.go -logstream=stderr 2> /dev/null
{"type":"IPFIX", ...}
{"type":"IPFIX", ...}
{"type":"IPFIX", ...}
```