### PR TITLE
goflow2: zero queue_size means blocking

### DIFF
--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -226,6 +226,10 @@ func main() {
 			queueSize = 1000000
 		}
 
+		if queueSize == 0 {
+			isBlocking = true
+		}
+
 		hostname := listenAddrUrl.Hostname()
 		port, err := strconv.ParseUint(listenAddrUrl.Port(), 10, 64)
 		if err != nil {


### PR DESCRIPTION
When queue size is zero, automatically set to blocking mode.