### PR TITLE
feat: add string renderer

### DIFF
--- a/producer/proto/messages.go
+++ b/producer/proto/messages.go
@@ -2,7 +2,6 @@ package protoproducer
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"hash"
 	"hash/fnv"
@@ -121,7 +120,8 @@ func (m *ProtoProducerMessage) mapUnknown() map[string]interface{} {
 				value = v
 			} else if dataType == protowire.BytesType {
 				v, _ := protowire.ConsumeString(data)
-				value = hex.EncodeToString([]byte(v))
+				//value = hex.EncodeToString([]byte(v)) // removed, this conversion is left to the renderer
+				value = []byte(v)
 			} else {
 				continue
 			}

--- a/producer/proto/messages_test.go
+++ b/producer/proto/messages_test.go
@@ -1,0 +1,63 @@
+package protoproducer
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	var m ProtoProducerMessage
+
+	m.formatter = &FormatterConfigMapper{
+		fields: []string{"Etype", "test1", "test2", "test3"},
+		rename: map[string]string{
+			"Etype": "etype",
+		},
+		numToPb: map[int32]ProtobufFormatterConfig{
+			100: ProtobufFormatterConfig{
+				Name:  "test1",
+				Index: 100,
+				Type:  "varint",
+				Array: false,
+			},
+			101: ProtobufFormatterConfig{
+				Name:  "test2",
+				Index: 101,
+				Type:  "string",
+				Array: false,
+			},
+			102: ProtobufFormatterConfig{
+				Name:  "test3",
+				Index: 102,
+				Type:  "string",
+				Array: false,
+			},
+		},
+		render: map[string]RenderFunc{
+			"Etype": EtypeRenderer,
+			"test1": EtypeRenderer,
+			"test2": NilRenderer,
+			//"test3": nil,
+		},
+	}
+
+	m.FlowMessage.Etype = 0x86dd
+
+	fmr := m.FlowMessage.ProtoReflect()
+	unk := fmr.GetUnknown()
+
+	unk = protowire.AppendTag(unk, protowire.Number(100), protowire.VarintType)
+	unk = protowire.AppendVarint(unk, 0x86dd)
+
+	unk = protowire.AppendTag(unk, protowire.Number(101), protowire.BytesType)
+	unk = protowire.AppendString(unk, string("testing"))
+
+	unk = protowire.AppendTag(unk, protowire.Number(102), protowire.BytesType)
+	unk = protowire.AppendString(unk, string("testing"))
+
+	fmr.SetUnknown(unk)
+
+	out, err := m.MarshalJSON()
+	t.Log(string(out), err)
+}

--- a/producer/proto/messages_test.go
+++ b/producer/proto/messages_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"google.golang.org/protobuf/encoding/protowire"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMarshalJSON(t *testing.T) {
@@ -30,7 +32,7 @@ func TestMarshalJSON(t *testing.T) {
 			102: ProtobufFormatterConfig{
 				Name:  "test3",
 				Index: 102,
-				Type:  "string",
+				Type:  "bytes",
 				Array: false,
 			},
 		},
@@ -38,7 +40,7 @@ func TestMarshalJSON(t *testing.T) {
 			"Etype": EtypeRenderer,
 			"test1": EtypeRenderer,
 			"test2": NilRenderer,
-			//"test3": nil,
+			"test3": StringRenderer,
 		},
 	}
 
@@ -54,10 +56,12 @@ func TestMarshalJSON(t *testing.T) {
 	unk = protowire.AppendString(unk, string("testing"))
 
 	unk = protowire.AppendTag(unk, protowire.Number(102), protowire.BytesType)
-	unk = protowire.AppendString(unk, string("testing"))
+	unk = protowire.AppendString(unk, string([]byte{0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67}))
 
 	fmr.SetUnknown(unk)
 
 	out, err := m.MarshalJSON()
-	t.Log(string(out), err)
+	assert.Nil(t, err)
+	t.Log(string(out))
+	assert.Equal(t, "{\"etype\":\"IPv6\",\"test1\":\"IPv6\",\"test2\":\"74657374696e67\",\"test3\":\"testing\"}", string(out))
 }

--- a/producer/proto/render.go
+++ b/producer/proto/render.go
@@ -151,6 +151,8 @@ func IPRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}) i
 func EtypeRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}) interface{} {
 	if dataC, ok := data.(uint32); ok {
 		return etypeName[dataC]
+	} else if dataC, ok := data.(uint64); ok { // supports protobuf mapped fields
+		return etypeName[uint32(dataC)]
 	}
 	return "unknown"
 }
@@ -158,6 +160,8 @@ func EtypeRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}
 func ProtoRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}) interface{} {
 	if dataC, ok := data.(uint32); ok {
 		return protoName[dataC]
+	} else if dataC, ok := data.(uint64); ok {
+		return protoName[uint32(dataC)]
 	}
 	return "unknown"
 }

--- a/producer/proto/render.go
+++ b/producer/proto/render.go
@@ -22,6 +22,7 @@ const (
 	RendererNetwork      RendererID = "network"
 	RendererDateTime     RendererID = "datetime"
 	RendererDateTimeNano RendererID = "datetimenano"
+	RendererString       RendererID = "string"
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 		RendererProto:        ProtoRenderer,
 		RendererDateTime:     DateTimeRenderer,
 		RendererDateTimeNano: DateTimeNanoRenderer,
+		RendererString:       StringRenderer,
 	}
 
 	defaultRenderers = map[string]RenderFunc{
@@ -93,6 +95,15 @@ func NilRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}) 
 		return hex.EncodeToString(dataC)
 	}
 	return data
+}
+
+func StringRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}) interface{} {
+	if dataC, ok := data.([]byte); ok {
+		return string(dataC)
+	} else if dataC, ok := data.(string); ok {
+		return string(dataC)
+	} // maybe should support uint64?
+	return NilRenderer(msg, fieldName, data)
 }
 
 func DateTimeRenderer(msg *ProtoProducerMessage, fieldName string, data interface{}) interface{} {


### PR DESCRIPTION
Add tests for formatting protobuf data that includes unknown fields (custom mapping)
Fix the function to get the bytes from protobuf instead of converting into hex
Add a string renderer to display text sent via samples

Closes #275