### PR TITLE
producer: mpls label, timediff multiplier, time_flow

### DIFF
--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -518,7 +518,9 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 				return err
 			}
 			if len(flowMessage.MplsLabel) < 2 {
-				flowMessage.MplsLabel = make([]uint32, 2)
+				tmpLabels := make([]uint32, 2)
+				copy(tmpLabels, flowMessage.MplsLabel)
+				flowMessage.MplsLabel = tmpLabels
 			}
 			flowMessage.MplsLabel[1] = uint32(mplsLabel >> 4)
 		case netflow.IPFIX_FIELD_mplsLabelStackSection3:
@@ -527,7 +529,9 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 				return err
 			}
 			if len(flowMessage.MplsLabel) < 3 {
-				flowMessage.MplsLabel = make([]uint32, 3)
+				tmpLabels := make([]uint32, 3)
+				copy(tmpLabels, flowMessage.MplsLabel)
+				flowMessage.MplsLabel = tmpLabels
 			}
 			flowMessage.MplsLabel[2] = uint32(mplsLabel >> 4)
 		case netflow.IPFIX_FIELD_mplsTopLabelIPv4Address:

--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -544,15 +544,15 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 					if err := DecodeUNumber(v, &timeFirstSwitched); err != nil {
 						return err
 					}
-					timeDiff := (uptime - timeFirstSwitched)
-					flowMessage.TimeFlowStartNs = baseTimeNs - uint64(timeDiff)*1000000000
+					timeDiff := (int64(uptime) - int64(timeFirstSwitched))
+					flowMessage.TimeFlowStartNs = uint64(int64(baseTime)*1000-timeDiff) * 1000000
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					if err := DecodeUNumber(v, &timeLastSwitched); err != nil {
 						return err
 					}
-					timeDiff := (uptime - timeLastSwitched)
-					flowMessage.TimeFlowEndNs = baseTimeNs - uint64(timeDiff)*1000000000
+					timeDiff := (int64(uptime) - int64(timeLastSwitched))
+					flowMessage.TimeFlowEndNs = uint64(int64(baseTime)*1000-timeDiff) * 1000000
 				}
 			} else if version == 10 {
 				switch df.Type {

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -28,6 +28,16 @@ func TestProcessMessageNetFlow(t *testing.T) {
 					// 218432192
 					Value: []byte{0x0d, 0x05, 0x02, 0xc0},
 				},
+				netflow.DataField{
+					Type: netflow.NFV9_FIELD_MPLS_LABEL_1,
+					// 24041
+					Value: []byte{0x05, 0xde, 0x94},
+				},
+				netflow.DataField{
+					Type: netflow.NFV9_FIELD_MPLS_LABEL_2,
+					// 211992
+					Value: []byte{0x33, 0xc1, 0x85},
+				},
 			},
 		},
 	}
@@ -49,6 +59,7 @@ func TestProcessMessageNetFlow(t *testing.T) {
 		if assert.True(t, ok) {
 			assert.Equal(t, msg.TimeFlowStartNs, uint64(1705732882176000000))
 			assert.Equal(t, msg.TimeFlowEndNs, uint64(1705732882192000000))
+			assert.Equal(t, msg.MplsLabel, []uint32{24041, 211992})
 		}
 	}
 

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -38,6 +38,11 @@ func TestProcessMessageNetFlow(t *testing.T) {
 					// 211992
 					Value: []byte{0x33, 0xc1, 0x85},
 				},
+				netflow.DataField{
+					Type: netflow.NFV9_FIELD_MPLS_LABEL_3,
+					// 48675
+					Value: []byte{0x0b, 0xe2, 0x35},
+				},
 			},
 		},
 	}
@@ -59,7 +64,7 @@ func TestProcessMessageNetFlow(t *testing.T) {
 		if assert.True(t, ok) {
 			assert.Equal(t, msg.TimeFlowStartNs, uint64(1705732882176000000))
 			assert.Equal(t, msg.TimeFlowEndNs, uint64(1705732882192000000))
-			assert.Equal(t, msg.MplsLabel, []uint32{24041, 211992})
+			assert.Equal(t, msg.MplsLabel, []uint32{24041, 211992, 48675})
 		}
 	}
 


### PR DESCRIPTION
This PR fixes 3 bugs:
- Changing timediff multiplier from 1e9 to 1e6. Based on [sysuptime header rfc](https://datatracker.ietf.org/doc/html/rfc3954#section-5.1) and [LAST_SWITCHED & FIRST_SWITCHED field rfc](https://datatracker.ietf.org/doc/html/rfc3954#section-8), everything is in milliseconds instead of seconds.
- Fixing uint underflow. Some flows do have weird data with `SysUptime < (LAST_SWITCHED | FIRST_SWITCHED)` which results in incorrect `time_flow_start_ns` and `time_flow_end_ns` fields. Check: [uint-underflow.pcap.zip](https://github.com/netsampler/goflow2/files/14063268/uint-overflow.pcap.zip)
- Mpls labels when having more than 1 elements will reset the previous value to zero

