### PR TITLE
FIX: couble count of flow_process_nf_total

### DIFF
--- a/metrics/producer.go
+++ b/metrics/producer.go
@@ -92,23 +92,11 @@ func (p *PromProducerWrapper) Produce(msg interface{}, args *producer.ProduceArg
 			Add(float64(packet.Count))
 
 	case *netflow.NFv9Packet:
-		NetFlowStats.With(
-			prometheus.Labels{
-				"router":  key,
-				"version": "9",
-			}).
-			Inc()
 		recordCommonNetFlowMetrics(9, key, packet.FlowSets)
 		nfvariant = true
 		versionStr = "9"
 
 	case *netflow.IPFIXPacket:
-		NetFlowStats.With(
-			prometheus.Labels{
-				"router":  key,
-				"version": "10",
-			}).
-			Inc()
 		recordCommonNetFlowMetrics(10, key, packet.FlowSets)
 		nfvariant = true
 		versionStr = "10"


### PR DESCRIPTION
I was confused about the latest total processed flow counts - if I interpreting it right, the metric of `flow_process_nf_total` is counted double for v9 and v10:

https://github.com/netsampler/goflow2/blob/ee095a980f28a9cd9b478e12b9ff7d41ba533762/metrics/producer.go#L106

and in the `recordCommonNetFlowMetrics` function:
https://github.com/netsampler/goflow2/blob/ee095a980f28a9cd9b478e12b9ff7d41ba533762/metrics/decoder.go#L89
