### PR TITLE
Make formatter and unknown fields public in ProtoProducerMessage

### DIFF
--- a/producer/proto/custom.go
+++ b/producer/proto/custom.go
@@ -80,6 +80,38 @@ type FormatterConfigMapper struct {
 	isSlice map[string]bool
 }
 
+func (m *FormatterConfigMapper) GetFields() []string {
+	return m.fields
+}
+
+func (m *FormatterConfigMapper) GetKey() []string {
+	return m.key
+}
+
+func (m *FormatterConfigMapper) GetReMap() map[string]string {
+	return m.reMap
+}
+
+func (m *FormatterConfigMapper) GetRenameMap() map[string]string {
+	return m.rename
+}
+
+func (m *FormatterConfigMapper) GetRenderers() map[string]RenderFunc {
+	return m.render
+}
+
+func (m *FormatterConfigMapper) GetPbMap() map[string]ProtobufFormatterConfig {
+	return m.pbMap
+}
+
+func (m *FormatterConfigMapper) GetNumToPbMap() map[int32]ProtobufFormatterConfig {
+	return m.numToPb
+}
+
+func (m *FormatterConfigMapper) GetIsSliceMap() map[string]bool {
+	return m.isSlice
+}
+
 type NetFlowMapper struct {
 	data map[string]DataMap // maps field to destination
 }


### PR DESCRIPTION
I propose to make formatter and unknown fields map more public in `protoproducer.ProtoProducerMessage` struct. 

The reason is that I try to create flows enrichment in custom formatter.

My struct is:

```go
type FlowMessage struct {
	*protoproducer.ProtoProducerMessage
	SrcCountry string `json:"src_country"`
	DstCountry string `json:"dst_country"`
	// other fields
}
```

In this scenario in method `Format(data interface{}) ([]byte, []byte, error)` I can fill additional fields without make a copy of original struct. But marshall to json needs to be done in three steps:
1. Marshal embedded struct to json with `m.ProtoProducerMessage.MarshalJSON()` to create unknownFields as fields in json and use renderers from config
2. Parse json into map, fill additional fields
3. Marshal map to json

With access to formatter from `ProtoProducerMessage` I could write more efficient json serializer with my fields.

I also need unknown fields for two reasons:
1. Custom json marshal (obvious ;-) ). If I will make more efficient json marshal function I will be happy to propose it in another PR,
2. I use expr to make some queries from flow, for example: `FlowDirection == "12345" and DstAddr == IP("1.1.2.2")`). `FlowDirection` is in UnknownFields, so I need to materialize them in my struct as map or fields.
