### PR TITLE
fix: flow_process_nf_delay_seconds metric is not observed

### DIFF
--- a/metrics/producer.go
+++ b/metrics/producer.go
@@ -6,8 +6,8 @@ import (
 	"github.com/netsampler/goflow2/v2/decoders/netflow"
 	"github.com/netsampler/goflow2/v2/decoders/netflowlegacy"
 	"github.com/netsampler/goflow2/v2/decoders/sflow"
-	flowmessage "github.com/netsampler/goflow2/v2/pb"
 	"github.com/netsampler/goflow2/v2/producer"
+	"github.com/netsampler/goflow2/v2/producer/proto"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -116,7 +116,7 @@ func (p *PromProducerWrapper) Produce(msg interface{}, args *producer.ProduceArg
 
 	if nfvariant {
 		for _, msg := range flowMessageSet {
-			fmsg, ok := msg.(*flowmessage.FlowMessage)
+			fmsg, ok := msg.(*protoproducer.ProtoProducerMessage)
 			if !ok {
 				continue
 			}

--- a/metrics/producer.go
+++ b/metrics/producer.go
@@ -117,7 +117,7 @@ func (p *PromProducerWrapper) Produce(msg interface{}, args *producer.ProduceArg
 	if nfvariant {
 		for _, msg := range flowMessageSet {
 			fmsg, ok := msg.(*protoproducer.ProtoProducerMessage)
-			if !ok {
+			if !ok || fmsg.TimeReceivedNs < fmsg.TimeFlowEndNs {
 				continue
 			}
 			timeDiff := fmsg.TimeReceivedNs - fmsg.TimeFlowEndNs

--- a/metrics/producer.go
+++ b/metrics/producer.go
@@ -126,7 +126,7 @@ func (p *PromProducerWrapper) Produce(msg interface{}, args *producer.ProduceArg
 					"router":  key,
 					"version": versionStr,
 				}).
-				Observe(float64(timeDiff))
+				Observe(float64(timeDiff) / 1e9)
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes three bugs regarding `flow_process_nf_delay_seconds` observation:

- `flowMessageSet` contains `*flowmessage.FlowMessage` instead of `*protoproducer.ProtoProducerMessage`
- `timeDiff` calculation might underflow in some corner cases (router/collector time is out of sync)
- Observed value is still in nanoseconds instead of seconds as mentioned on metric name