### PR TITLE
bug: fix builds to push latest tag

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -39,3 +39,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-release-buildx
+        VERSION=latest make docker-manifest-buildx

--- a/.github/workflows/docker-release_registry_github.yml
+++ b/.github/workflows/docker-release_registry_github.yml
@@ -44,3 +44,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-release-buildx
+        VERSION=latest make docker-manifest-buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,3 +37,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-buildx
+        VERSION=latest make docker-manifest-buildx

--- a/.github/workflows/docker_registry_github.yml
+++ b/.github/workflows/docker_registry_github.yml
@@ -37,3 +37,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-buildx
+        VERSION=latest make docker-manifest-buildx


### PR DESCRIPTION
`latest` tag hasn't been [pushed in a year](https://hub.docker.com/layers/netsampler/goflow2/latest/images/sha256-0276430774c1f5741262098cb426f3ef7147869a5fb65728a02f31c783bafc5c?context=explore). Fixes it.

Closes #286 