### PR TITLE
bug: fix builds to push latest tag

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -39,4 +39,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-release-buildx
-        VERSION=latest make docker-manifest-buildx
+        export VERSION=latest && make docker-manifest-buildx

--- a/.github/workflows/docker-release_registry_github.yml
+++ b/.github/workflows/docker-release_registry_github.yml
@@ -44,4 +44,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-release-buildx
-        VERSION=latest make docker-manifest-buildx
+        export VERSION=latest && make docker-manifest-buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,4 +37,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-buildx
-        VERSION=latest make docker-manifest-buildx
+        export VERSION=latest && make docker-manifest-buildx

--- a/.github/workflows/docker_registry_github.yml
+++ b/.github/workflows/docker_registry_github.yml
@@ -37,4 +37,4 @@ jobs:
         DOCKER_SUFFIX=-amd64 DOCKER_CMD='buildx build --push --platform linux/amd64' make docker
         DOCKER_SUFFIX=-arm64 DOCKER_CMD='buildx build --push --platform linux/arm64/v8' make docker
         make docker-manifest-buildx
-        VERSION=latest make docker-manifest-buildx
+        export VERSION=latest && make docker-manifest-buildx


### PR DESCRIPTION
It seems #299 did not fix the issue. Trying an updated workflow.