### PR TITLE
Add transport driver for http

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `format` directory offers various utilities to format a message. It calls sp
 functions to marshal as JSON or text for instance.
 
 The `transport` provides different way of processing the message. Either sending it via Kafka or 
-send it to a file (or stdout).
+send it to a file (or stdout), or send it via HTTP.
 
 GoFlow2 is a wrapper of all the functions and chains them.
 
@@ -85,6 +85,7 @@ Production:
 * Convert to protobuf or json
 * Prints to the console/file
 * Sends to Kafka and partition
+* Sends to HTTP endpoint
 
 Monitoring via Prometheus metrics
 
@@ -152,6 +153,15 @@ To change the kafka compression type of the producer side configure the followin
 ```
 The list of codecs is available in the [Sarama documentation](https://pkg.go.dev/github.com/Shopify/sarama#CompressionCodec).
 
+If you are using http endpoint(e.g: Fluent Bit HTTP input plugin), use the following arguments:
+
+```bash
+$ ./goflow2 -transport=http \
+  -transport.http.server=localhost \
+  -transport.http.port=4739 \
+  -format=json \
+  -transport.http.tag=tagname
+```
 
 By default, the collector will listen for IPFIX/NetFlow V9 on port 2055
 and sFlow on port 6343.

--- a/cmd/enricher/main.go
+++ b/cmd/enricher/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/netsampler/goflow2/v2/transport"
 	_ "github.com/netsampler/goflow2/v2/transport/file"
 	_ "github.com/netsampler/goflow2/v2/transport/kafka"
+	_ "github.com/netsampler/goflow2/v2/transport/http"
 
 	"github.com/oschwald/geoip2-golang"
 	log "github.com/sirupsen/logrus"

--- a/cmd/goflow2/main.go
+++ b/cmd/goflow2/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/netsampler/goflow2/v2/transport"
 	_ "github.com/netsampler/goflow2/v2/transport/file"
 	_ "github.com/netsampler/goflow2/v2/transport/kafka"
+	_ "github.com/netsampler/goflow2/v2/transport/http"
 
 	// various producers
 	"github.com/netsampler/goflow2/v2/producer"

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -1,0 +1,82 @@
+package http
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/netsampler/goflow2/v2/transport"
+)
+
+type HttpDriver struct {
+	HttpServer string
+	HttpPort   string
+	HttpTag    string
+	q          chan bool
+
+	errors chan error
+}
+
+func (d *HttpDriver) Prepare() error {
+	flag.StringVar(&d.HttpServer, "transport.http.server", "localhost", "HTTP Post destination")
+	flag.StringVar(&d.HttpPort, "transport.http.port", "8080", "HTTP port")
+	flag.StringVar(&d.HttpTag, "transport.http.tag", "", "HTTP tag")
+	return nil
+}
+
+func (d *HttpDriver) Errors() <-chan error {
+	return d.errors
+}
+
+func (d *HttpDriver) Init() error {
+	d.q = make(chan bool)
+	go func() {
+		for {
+			<-d.q
+			return
+		}
+	}()
+	return nil
+}
+
+func (d *HttpDriver) Send(key, data []byte) error {
+	url := fmt.Sprintf("http://%s:%s/%s", d.HttpServer, d.HttpPort, d.HttpTag)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		fmt.Println("Error creating request:", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println("Error sending request:", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("Error reading response:%s, Response status:%s, Response body:%s", err, resp.Status, string(body))
+		return err
+	}
+	return nil
+}
+
+func (d *HttpDriver) Close() error {
+	close(d.q)
+	return nil
+}
+
+func init() {
+	d := &HttpDriver{
+		errors: make(chan error),
+	}
+	transport.RegisterTransportDriver("http", d)
+}


### PR DESCRIPTION
In order to support sending a processed message to http endpoint(e.g: Fluent Bit HTTP input plugin), adding transport driver for http.

Here is example:

```bash
$ ./goflow2 -transport=http \
  -transport.http.server=localhost \
  -transport.http.port=4739 \
  -format=json \
  -transport.http.tag=tagname
```