### PR TITLE
Fix.listen ipv6

### DIFF
--- a/utils/udp.go
+++ b/utils/udp.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"strconv"
 	"sync"
 	"time"
 
@@ -130,7 +129,7 @@ func (r *UDPReceiver) Errors() <-chan error {
 }
 
 func (r *UDPReceiver) receive(addr string, port int, started chan bool) error {
-	pconn, err := reuseport.ListenPacket("udp", net.JoinHostPort(addr, strconv.Itoa(port)))
+	pconn, err := reuseport.ListenPacket("udp", net.JoinHostPort(addr, fmt.Sprintf("%d", port)))
 	close(started)
 	if err != nil {
 		return err

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strconv"
 	"sync"
 	"time"
 
@@ -129,7 +130,7 @@ func (r *UDPReceiver) Errors() <-chan error {
 }
 
 func (r *UDPReceiver) receive(addr string, port int, started chan bool) error {
-	pconn, err := reuseport.ListenPacket("udp", fmt.Sprintf("%s:%d", addr, port))
+	pconn, err := reuseport.ListenPacket("udp", net.JoinHostPort(addr, strconv.Itoa(port)))
 	close(started)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hello.

fmt.Sprintf("%s:%d", addr, port) works incorrect for ipv6 addr.
For example, if addr = "::", port = 444, this code returns ":::444". The ":::444" is incorrect address for using in reuseport.ListenPacket().

net.JoinHostPort() supports ipv6 addresses and returns "[host]:port".

Without this fix UDPReceiver does not work with ipv6 addresses.

Thank you.