### PR TITLE
fix: udp receiver not passing errors

### DIFF
--- a/utils/udp.go
+++ b/utils/udp.go
@@ -148,7 +148,7 @@ func (r *UDPReceiver) receive(addr string, port int, started chan bool) error {
 
 	udpconn, ok := pconn.(*net.UDPConn)
 	if !ok {
-		return err
+		return fmt.Errorf("not a udp connection")
 	}
 
 	return r.receiveRoutine(udpconn)

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -291,7 +291,7 @@ func (r *UDPReceiver) Start(addr string, port int, decodeFunc DecoderFunc) error
 		r.Stop()
 		return err
 	}
-	if err := r.receivers(r.workers, addr, port); err != nil {
+	if err := r.receivers(r.sockets, addr, port); err != nil {
 		r.Stop()
 		return err
 	}

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"time"
 
@@ -129,6 +130,10 @@ func (r *UDPReceiver) Errors() <-chan error {
 }
 
 func (r *UDPReceiver) receive(addr string, port int, started chan bool) error {
+	if strings.IndexRune(addr, ':') >= 0 && strings.IndexRune(addr, '[') == -1 {
+		addr = "[" + addr + "]"
+	}
+
 	pconn, err := reuseport.ListenPacket("udp", fmt.Sprintf("%s:%d", addr, port))
 	if err != nil {
 		return err

--- a/utils/udp.go
+++ b/utils/udp.go
@@ -150,6 +150,11 @@ func (r *UDPReceiver) receive(addr string, port int, started chan bool) error {
 	if !ok {
 		return err
 	}
+
+	return r.receiveRoutine(udpconn)
+}
+
+func (r *UDPReceiver) receiveRoutine(udpconn *net.UDPConn) (err error) {
 	localAddr, _ := udpconn.LocalAddr().(*net.UDPAddr)
 
 	for {


### PR DESCRIPTION
A bug in which running:

```
go run cmd/goflow2/main.go -listen sflow://::1:6343/\?count=10
```

would not break