### PR TITLE
fix: NetFlow v9 bad timestamp calculation

### DIFF
--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -538,7 +538,7 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 		default:
 			if version == 9 {
 				// NetFlow v9 time works with a differential based on router's uptime
-				uptimeNs := uint64(uptime * 1e6) // uptime is in milliseconds in NetFlow v9, converts to nanoseconds
+				uptimeNs := uint64(uptime) * 1e6 // uptime is in milliseconds in NetFlow v9, converts to nanoseconds
 				switch df.Type {
 				case netflow.NFV9_FIELD_FIRST_SWITCHED:
 					var timeFirstSwitched uint32
@@ -547,6 +547,7 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 					}
 					timeDiff := (uptimeNs - uint64(timeFirstSwitched)*1e6)
 					flowMessage.TimeFlowStartNs = baseTimeNs - timeDiff
+
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					if err := DecodeUNumber(v, &timeLastSwitched); err != nil {

--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -538,21 +538,22 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 		default:
 			if version == 9 {
 				// NetFlow v9 time works with a differential based on router's uptime
+				uptimeNs := uint64(uptime * 1e6) // uptime is in milliseconds in NetFlow v9, converts to nanoseconds
 				switch df.Type {
 				case netflow.NFV9_FIELD_FIRST_SWITCHED:
 					var timeFirstSwitched uint32
 					if err := DecodeUNumber(v, &timeFirstSwitched); err != nil {
 						return err
 					}
-					timeDiff := (uptime - timeFirstSwitched)
-					flowMessage.TimeFlowStartNs = baseTimeNs - uint64(timeDiff)*1000000000
+					timeDiff := (uptimeNs - uint64(timeFirstSwitched)*1e9)
+					flowMessage.TimeFlowStartNs = baseTimeNs - timeDiff
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					if err := DecodeUNumber(v, &timeLastSwitched); err != nil {
 						return err
 					}
-					timeDiff := (uptime - timeLastSwitched)
-					flowMessage.TimeFlowEndNs = baseTimeNs - uint64(timeDiff)*1000000000
+					timeDiff := (uptimeNs - uint64(timeLastSwitched)*1e9)
+					flowMessage.TimeFlowEndNs = baseTimeNs - timeDiff
 				}
 			} else if version == 10 {
 				switch df.Type {

--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -547,7 +547,6 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 					}
 					timeDiff := (uptimeNs - uint64(timeFirstSwitched)*1e6)
 					flowMessage.TimeFlowStartNs = baseTimeNs - timeDiff
-
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					if err := DecodeUNumber(v, &timeLastSwitched); err != nil {

--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -545,14 +545,14 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 					if err := DecodeUNumber(v, &timeFirstSwitched); err != nil {
 						return err
 					}
-					timeDiff := (uptimeNs - uint64(timeFirstSwitched)*1e9)
+					timeDiff := (uptimeNs - uint64(timeFirstSwitched)*1e6)
 					flowMessage.TimeFlowStartNs = baseTimeNs - timeDiff
 				case netflow.NFV9_FIELD_LAST_SWITCHED:
 					var timeLastSwitched uint32
 					if err := DecodeUNumber(v, &timeLastSwitched); err != nil {
 						return err
 					}
-					timeDiff := (uptimeNs - uint64(timeLastSwitched)*1e9)
+					timeDiff := (uptimeNs - uint64(timeLastSwitched)*1e6)
 					flowMessage.TimeFlowEndNs = baseTimeNs - timeDiff
 				}
 			} else if version == 10 {

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -262,3 +262,16 @@ func TestProcessIPv4Fragment(t *testing.T) {
 	assert.Equal(t, uint32(24025), flowMessage.FragmentId)
 	assert.Equal(t, uint32(185), flowMessage.FragmentOffset)
 }
+
+func TestNetFlowV9Time(t *testing.T) {
+	var flowMessage ProtoProducerMessage
+	err := ConvertNetFlowDataSet(&flowMessage, 9, 1704067200, 2000, []netflow.DataField{
+		netflow.DataField{
+			Type:  netflow.NFV9_FIELD_FIRST_SWITCHED,
+			Value: []byte{0x0, 0x0, 0x03, 0xe8}, // 1000
+		},
+	}, nil, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(1704067199)*1e9, flowMessage.TimeFlowStartNs)
+
+}

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -264,6 +264,10 @@ func TestProcessIPv4Fragment(t *testing.T) {
 }
 
 func TestNetFlowV9Time(t *testing.T) {
+	// This test ensures the NetFlow v9 timestamps are properly calculated.
+	// It passes a baseTime = 2024-01-01 00:00:00 (in seconds) and an uptime of 2 seconds  (in milliseconds).
+	// The flow record was logged at 1 second of uptime (in milliseconds).
+	// The calculation is the following: baseTime - uptime + flowUptime.
 	var flowMessage ProtoProducerMessage
 	err := ConvertNetFlowDataSet(&flowMessage, 9, 1704067200, 2000, []netflow.DataField{
 		netflow.DataField{

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -273,5 +273,4 @@ func TestNetFlowV9Time(t *testing.T) {
 	}, nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(1704067199)*1e9, flowMessage.TimeFlowStartNs)
-
 }


### PR DESCRIPTION
The uptime is in milliseconds and not seconds.
NetFlow v9 producer had a bug and the timestamps were wrong.

Closes #313 and #305