### PR TITLE
fix(producer): mpls labels in NetFlow

### DIFF
--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -518,7 +518,9 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 				return err
 			}
 			if len(flowMessage.MplsLabel) < 2 {
-				flowMessage.MplsLabel = make([]uint32, 2)
+				tmpLabels := make([]uint32, 2)
+				copy(tmpLabels, flowMessage.MplsLabel)
+				flowMessage.MplsLabel = tmpLabels
 			}
 			flowMessage.MplsLabel[1] = uint32(mplsLabel >> 4)
 		case netflow.IPFIX_FIELD_mplsLabelStackSection3:
@@ -527,7 +529,9 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 				return err
 			}
 			if len(flowMessage.MplsLabel) < 3 {
-				flowMessage.MplsLabel = make([]uint32, 3)
+				tmpLabels := make([]uint32, 3)
+				copy(tmpLabels, flowMessage.MplsLabel)
+				flowMessage.MplsLabel = tmpLabels
 			}
 			flowMessage.MplsLabel[2] = uint32(mplsLabel >> 4)
 		case netflow.IPFIX_FIELD_mplsTopLabelIPv4Address:

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -58,9 +58,9 @@ func TestProcessMessageNetFlow(t *testing.T) {
 	if assert.Nil(t, err) && assert.Len(t, msgs, 1) {
 		msg, ok := msgs[0].(*ProtoProducerMessage)
 		if assert.True(t, ok) {
-			assert.Equal(t, msg.TimeFlowStartNs, uint64(1705732882176000000))
-			assert.Equal(t, msg.TimeFlowEndNs, uint64(1705732882192000000))
-			assert.Equal(t, msg.MplsLabel, []uint32{24041, 211992, 48675})
+			assert.Equal(t, uint64(218432176*1e6), msg.TimeFlowStartNs)
+			assert.Equal(t, uint64(218432192*1e6), msg.TimeFlowEndNs)
+			assert.Equal(t, []uint32{24041, 211992, 48675}, msg.MplsLabel)
 		}
 	}
 

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -36,6 +36,11 @@ func TestProcessMessageNetFlow(t *testing.T) {
 					// 211992
 					Value: []byte{0x33, 0xc1, 0x85},
 				},
+				netflow.DataField{
+					Type: netflow.NFV9_FIELD_MPLS_LABEL_3,
+					// 48675
+					Value: []byte{0x0b, 0xe2, 0x35},
+				},
 			},
 		},
 	}
@@ -55,7 +60,7 @@ func TestProcessMessageNetFlow(t *testing.T) {
 		if assert.True(t, ok) {
 			assert.Equal(t, msg.TimeFlowStartNs, uint64(1705732882176000000))
 			assert.Equal(t, msg.TimeFlowEndNs, uint64(1705732882192000000))
-			assert.Equal(t, msg.MplsLabel, []uint32{24041, 211992})
+			assert.Equal(t, msg.MplsLabel, []uint32{24041, 211992, 48675})
 		}
 	}
 

--- a/producer/proto/producer_test.go
+++ b/producer/proto/producer_test.go
@@ -51,15 +51,17 @@ func TestProcessMessageNetFlow(t *testing.T) {
 	}
 
 	pktnf9 := netflow.NFv9Packet{
-		FlowSets: dfs,
+		SystemUptime: 218432000,
+		UnixSeconds:  1705732882,
+		FlowSets:     dfs,
 	}
 	testsr := &SingleSamplingRateSystem{1}
 	msgs, err := ProcessMessageNetFlowV9Config(&pktnf9, testsr, nil)
 	if assert.Nil(t, err) && assert.Len(t, msgs, 1) {
 		msg, ok := msgs[0].(*ProtoProducerMessage)
 		if assert.True(t, ok) {
-			assert.Equal(t, uint64(218432176*1e6), msg.TimeFlowStartNs)
-			assert.Equal(t, uint64(218432192*1e6), msg.TimeFlowEndNs)
+			assert.Equal(t, uint64(1705732882176*1e6), msg.TimeFlowStartNs)
+			assert.Equal(t, uint64(1705732882192*1e6), msg.TimeFlowEndNs)
 			assert.Equal(t, []uint32{24041, 211992, 48675}, msg.MplsLabel)
 		}
 	}


### PR DESCRIPTION
This was brought by @iqbalaydrus. Cherry-picked the MPLS fixes (the timestamps had been fixed prior).
Closes #284.