### PR TITLE
fix(producer): should parse with empty config

### DIFF
--- a/producer/proto/config_impl.go
+++ b/producer/proto/config_impl.go
@@ -203,7 +203,7 @@ func (m *SFlowMapper) Map(layer string) MapLayerIterator {
 
 func (m *SFlowMapper) ParsePacket(flowMessage ProtoProducerMessageIf, data []byte) (err error) {
 	if m == nil {
-		return nil
+		return ParsePacket(flowMessage, data, m, DefaultEnvironment)
 	}
 	return ParsePacket(flowMessage, data, m, m.parserEnvironment)
 }


### PR DESCRIPTION
Closes #346

Introduced a bug and did not catch the scenario when the configuration is `nil`.