### PR TITLE
feat(makefile): use CGO_EXTERNAL to generate a static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 
 .PHONY: build
 build: prepare
-	go build -ldflags $(LDFLAGS) -o $(OUTPUT) cmd/goflow2/main.go 
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o $(OUTPUT) cmd/goflow2/main.go
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
Fixes #381