### PR TITLE
Remove mention of Zookeeper in kcg example

### DIFF
--- a/compose/kcg/README.md
+++ b/compose/kcg/README.md
@@ -5,7 +5,6 @@ Clickhouse is a powerful data warehouse.
 A sample [docker-compose](./docker-compose.yml) is provided.
 It's composed of:
 * Apache Kafka
-* Apache Zookeeper
 * GoFlow2
 * Prometheus
 * Clickhouse
@@ -19,7 +18,6 @@ $ docker-compose up
 This command will automatically build Grafana and GoFlow2 containers.
 
 GoFlow2 collects NetFlow v9/IPFIX and sFlow packets and sends as a protobuf into Kafka.
-Zookeeper coordinates Kafka and can also be used by Clickhouse to ensure replication.
 Prometheus scrapes the metrics of the collector.
 Clickhouse consumes from Kafka, stores raw data and aggregates over specific columns
 using `MATERIALIZED TABLES` and `VIEWS` defined in a [schema file](./clickhouse/create.sh).


### PR DESCRIPTION
There is no Zookeper in the Docker Compose anymore, so we can remove it from the README as well.