### PR TITLE
Fix: consider relative ipfix timestamps

### DIFF
--- a/producer/proto/producer_nf.go
+++ b/producer/proto/producer_nf.go
@@ -569,6 +569,13 @@ func ConvertNetFlowDataSet(flowMessage *ProtoProducerMessage, version uint16, ba
 				}
 			} else if version == 10 {
 				switch df.Type {
+				case netflow.IPFIX_FIELD_flowStartSysUpTime:
+					flowMessage.TimeFlowStartNs = uint64(binary.BigEndian.Uint32(v)) * 1e6
+				case netflow.IPFIX_FIELD_flowEndSysUpTime:
+					flowMessage.TimeFlowEndNs = uint64(binary.BigEndian.Uint32(v)) * 1e6
+				case netflow.IPFIX_FIELD_systemInitTimeMilliseconds:
+					flowMessage.TimeFlowStartNs += binary.BigEndian.Uint64(v) * 1e6
+					flowMessage.TimeFlowEndNs += binary.BigEndian.Uint64(v) * 1e6
 				case netflow.IPFIX_FIELD_flowStartSeconds:
 					if err := DecodeUNumber(v, &time); err != nil {
 						return err


### PR DESCRIPTION
The builtin netflow exporter of mikrotik routers uses the fields
- flowStartSysUpTime (22)
-  flowEndSysUpTime (21)
-  systemInitTimeMilliseconds (160)

to determine the flow start and end timestamps at millisecond precision by adding the relative values of flowStart and flowEnd to the system init time. 

These fields are not yet considered by goflow2 and hence the timestamps were left at their default value that corresponds to the export time. This fix is a quick and dirty workaround to address this problem.
Caution: The logic only works if the systemInitTimeMilliseconds field appears after the flowStartSysUpTime/flowEndSysUpTime in the set, which is the case for IPFIX packets originated from the Mikrotik netflow exporter. I'm not sure if this is a MUST, hence the caveat.