### PR TITLE
feat(ipfix): encode bytes as string for VRF name

### DIFF
--- a/decoders/netflow/netflow.go
+++ b/decoders/netflow/netflow.go
@@ -224,8 +224,15 @@ func DecodeDataSetUsingFields(version uint16, payload *bytes.Buffer, listFields 
 					finalLength = int(variableLen8)
 				}
 			}
+			var value any
+			valueBytes := payload.Next(finalLength)
 
-			value := payload.Next(finalLength)
+			if templateField.Type == IPFIX_FIELD_VRFname {
+				value = string(valueBytes)
+			} else {
+				value = valueBytes
+			}
+
 			nfvalue := DataField{
 				Type:        templateField.Type,
 				PenProvided: templateField.PenProvided,


### PR DESCRIPTION
Some fields have a specific type that can be decoded early making better for the JSON output in the end. (According to https://www.iana.org/assignments/ipfix/ipfix.xhtml). 
This way, the Vrf Name is written as a string instead of bytes that needs to be decoded.

Maybe we should have a generic map containing mapping field => function type instead ? Wdyt ? 