### PR TITLE
Replace bitnami Kafka image with soldevelo/kafka

### DIFF
--- a/compose/kcg/docker-compose.yml
+++ b/compose/kcg/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kafka:
-    image: bitnami/kafka:3.9.0
+    image: soldevelo/kafka:3.9.0
     ports:
       - 9092:9092
     environment:


### PR DESCRIPTION
Soldevelo image is a drop-in replacement that remains fully compatible with Bitnami’s configuration and environment variables.

The Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.
Switching to Soldevelo’s maintained image ensures:
* continued compatibility with existing Kafka setup,
* availability of regular updates and security patches,
* use of an image from a trusted and open source provider.