### PR TITLE
fix(sflow): parser calls counter incremented on wrong index causing ICMP fields always zero

### DIFF
--- a/producer/proto/producer_packet.go
+++ b/producer/proto/producer_packet.go
@@ -458,9 +458,10 @@ func ParsePacket(flowMessage ProtoProducerMessageIf, data []byte, config PacketL
 			parseConfig.Encapsulated = true
 		}
 
-		nextParser = res.NextParser
 		calls[nextParser.ParserIndex] += 1
 		callsLayer[nextParser.LayerIndex] += 1
+
+		nextParser = res.NextParser
 
 		offset += res.Size
 	}


### PR DESCRIPTION
In ParsePacket (producer/proto/producer_packet.go), the calls counter determines whether a parser is being invoked for the first time. This is used by ParseICMP and ParseICMPv6 to guard IcmpType/IcmpCode assignment with pc.Calls == 0.

However, the counter is incremented on the next parser's index rather than the current parser's index:
```
res, err := nextParser.Parser(...)       // call current parser
// ...
nextParser = res.NextParser
calls[nextParser.ParserIndex] += 1        // BUG: increments the next parser, not current
```

This causes the next parser in the chain to see pc.Calls == 1 on its first invocation, making the pc.Calls == 0 guard always evaluate to false. As a result:
- ParseICMP never sets IcmpType / IcmpCode
- ParseICMPv6 never sets IcmpType / IcmpCode

All ICMP and ICMPv6 flows parsed through the SampledHeader sFlow path or ParsePacket have icmp_type=0 and icmp_code=0 regardless of the actual packet content.

## Minimal reproduction
Parse an ICMP Echo Request packet (type=8, code=0) through ParsePacket:
```
// Ethernet + IPv4 + ICMP Echo Request
data, _ := hex.DecodeString("f42d064fb7cf90744ae1f4ce08004500001c897a400040010000c0a8060dc0a806010800000000010001")
ParsePacket(&flowMessage, data, nil, DefaultEnvironment)
// Expected: IcmpType=8, IcmpCode=0
// Actual:   IcmpType=0, IcmpCode=0
```

## FIX
Swap the order so the counter is incremented on the current parser before nextParser is reassigned:
```
calls[nextParser.ParserIndex] += 1
callsLayer[nextParser.LayerIndex] += 1

nextParser = res.NextParser
```