### PR TITLE
docs(kafka): fix README compression flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ By default, compression is disabled when sending data to Kafka.
 To change the kafka compression type of the producer side configure the following option:
 
 ```
--transport.kafka.compression.type=gzip
+-transport.kafka.compression=gzip
 ```
 The list of codecs is available in the [Sarama documentation](https://pkg.go.dev/github.com/Shopify/sarama#CompressionCodec).
 


### PR DESCRIPTION
## Summary
- fix the Kafka compression flag example in `README.md`
- align the documented option with the actual `transport.kafka.compression` CLI flag