### PR TITLE
fix(sflow): preserve ICMP type and code in packet parsing

### DIFF
--- a/producer/proto/producer_packet.go
+++ b/producer/proto/producer_packet.go
@@ -451,9 +451,10 @@ func ParsePacket(flowMessage ProtoProducerMessageIf, data []byte, config PacketL
 			parseConfig.Encapsulated = true
 		}
 
-		nextParser = res.NextParser
 		calls[nextParser.ParserIndex] += 1
 		callsLayer[nextParser.LayerIndex] += 1
+
+		nextParser = res.NextParser
 
 		offset += res.Size
 	}

--- a/producer/proto/producer_packet_test.go
+++ b/producer/proto/producer_packet_test.go
@@ -182,6 +182,8 @@ func TestProcessPacketBase(t *testing.T) {
 	}
 
 	assert.Equal(t, uint32(0x86dd), flowMessage.Etype)
+	assert.Equal(t, uint32(128), flowMessage.IcmpType)
+	assert.Equal(t, uint32(0), flowMessage.IcmpCode)
 
 }
 
@@ -222,6 +224,8 @@ func TestProcessPacketGRE(t *testing.T) {
 
 	assert.Equal(t, uint32(0x86dd), flowMessage.Etype)
 	assert.Equal(t, uint32(47), flowMessage.Proto)
+	assert.Equal(t, uint32(1), flowMessage.IcmpType)
+	assert.Equal(t, uint32(1), flowMessage.IcmpCode)
 	// todo: check addresses
 
 }


### PR DESCRIPTION
Backports #506 to the v2 branch.

This fixes packet parsing so parser call counters are incremented for the parser that just ran, not the next parser. That lets ICMP and ICMPv6 parsing see their first invocation correctly and preserve type/code fields.