### PR TITLE
fix(sflow): XDR-align MAC addresses in SampledEthernet decode/encode

### DIFF
--- a/decoders/sflow/encode.go
+++ b/decoders/sflow/encode.go
@@ -383,10 +383,16 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 			return err
 		}
 		// MAC addresses are XDR-padded to 8 bytes (6 bytes + 2 zero pad bytes).
-		if _, err := payload.Write(append(append([]byte{}, data.SrcMac...), 0, 0)); err != nil {
+		if _, err := payload.Write(data.SrcMac); err != nil {
 			return err
 		}
-		if _, err := payload.Write(append(append([]byte{}, data.DstMac...), 0, 0)); err != nil {
+		if err := utils.WriteU16(payload, 0); err != nil {
+			return err
+		}
+		if _, err := payload.Write(data.DstMac); err != nil {
+			return err
+		}
+		if err := utils.WriteU16(payload, 0); err != nil {
 			return err
 		}
 		if err := utils.WriteU32(payload, data.EthType); err != nil {
@@ -403,10 +409,16 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 			return err
 		}
 		// MAC addresses are XDR-padded to 8 bytes (6 bytes + 2 zero pad bytes).
-		if _, err := payload.Write(append(append([]byte{}, data.SrcMac...), 0, 0)); err != nil {
+		if _, err := payload.Write(data.SrcMac); err != nil {
 			return err
 		}
-		if _, err := payload.Write(append(append([]byte{}, data.DstMac...), 0, 0)); err != nil {
+		if err := utils.WriteU16(payload, 0); err != nil {
+			return err
+		}
+		if _, err := payload.Write(data.DstMac); err != nil {
+			return err
+		}
+		if err := utils.WriteU16(payload, 0); err != nil {
 			return err
 		}
 		if err := utils.WriteU32(payload, data.EthType); err != nil {

--- a/decoders/sflow/encode.go
+++ b/decoders/sflow/encode.go
@@ -382,10 +382,11 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 		if err := utils.WriteU32(payload, data.Length); err != nil {
 			return err
 		}
-		if _, err := payload.Write(data.SrcMac); err != nil {
+		// MAC addresses are XDR-padded to 8 bytes (6 bytes + 2 zero pad bytes).
+		if _, err := payload.Write(append(append([]byte{}, data.SrcMac...), 0, 0)); err != nil {
 			return err
 		}
-		if _, err := payload.Write(data.DstMac); err != nil {
+		if _, err := payload.Write(append(append([]byte{}, data.DstMac...), 0, 0)); err != nil {
 			return err
 		}
 		if err := utils.WriteU32(payload, data.EthType); err != nil {
@@ -401,10 +402,11 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 		if err := utils.WriteU32(payload, data.Length); err != nil {
 			return err
 		}
-		if _, err := payload.Write(data.SrcMac); err != nil {
+		// MAC addresses are XDR-padded to 8 bytes (6 bytes + 2 zero pad bytes).
+		if _, err := payload.Write(append(append([]byte{}, data.SrcMac...), 0, 0)); err != nil {
 			return err
 		}
-		if _, err := payload.Write(data.DstMac); err != nil {
+		if _, err := payload.Write(append(append([]byte{}, data.DstMac...), 0, 0)); err != nil {
 			return err
 		}
 		if err := utils.WriteU32(payload, data.EthType); err != nil {

--- a/decoders/sflow/sflow.go
+++ b/decoders/sflow/sflow.go
@@ -200,18 +200,24 @@ func DecodeFlowRecord(header *RecordHeader, payload *bytes.Buffer) (FlowRecord, 
 		sampledHeader.HeaderData = payload.Bytes()
 		flowRecord.Data = sampledHeader
 	case FLOW_TYPE_ETH:
+		// Per sFlow v5 (RFC 3176), MAC addresses are encoded as XDR opaque
+		// fixed-length and padded to a multiple of 4 bytes. A 6-byte MAC is
+		// transmitted as 8 bytes (6 bytes of address + 2 zero pad bytes).
+		var srcMacPadded, dstMacPadded [8]byte
 		sampledEth := SampledEthernet{
 			SrcMac: make([]byte, 6),
 			DstMac: make([]byte, 6),
 		}
 		if err := utils.BinaryDecoder(payload,
 			&sampledEth.Length,
-			sampledEth.SrcMac,
-			sampledEth.DstMac,
+			srcMacPadded[:],
+			dstMacPadded[:],
 			&sampledEth.EthType,
 		); err != nil {
 			return flowRecord, &RecordError{header.DataFormat, err}
 		}
+		copy(sampledEth.SrcMac, srcMacPadded[:6])
+		copy(sampledEth.DstMac, dstMacPadded[:6])
 		flowRecord.Data = sampledEth
 	case FLOW_TYPE_IPV4:
 		sampledIP := SampledIPv4{

--- a/decoders/sflow/sflow.go
+++ b/decoders/sflow/sflow.go
@@ -203,21 +203,21 @@ func DecodeFlowRecord(header *RecordHeader, payload *bytes.Buffer) (FlowRecord, 
 		// Per sFlow v5 (RFC 3176), MAC addresses are encoded as XDR opaque
 		// fixed-length and padded to a multiple of 4 bytes. A 6-byte MAC is
 		// transmitted as 8 bytes (6 bytes of address + 2 zero pad bytes).
-		var srcMacPadded, dstMacPadded [8]byte
 		sampledEth := SampledEthernet{
 			SrcMac: make([]byte, 6),
 			DstMac: make([]byte, 6),
 		}
+		var srcMacPad, dstMacPad uint16
 		if err := utils.BinaryDecoder(payload,
 			&sampledEth.Length,
-			srcMacPadded[:],
-			dstMacPadded[:],
+			sampledEth.SrcMac,
+			&srcMacPad,
+			sampledEth.DstMac,
+			&dstMacPad,
 			&sampledEth.EthType,
 		); err != nil {
 			return flowRecord, &RecordError{header.DataFormat, err}
 		}
-		copy(sampledEth.SrcMac, srcMacPadded[:6])
-		copy(sampledEth.DstMac, dstMacPadded[:6])
 		flowRecord.Data = sampledEth
 	case FLOW_TYPE_IPV4:
 		sampledIP := SampledIPv4{

--- a/decoders/sflow/sflow_test.go
+++ b/decoders/sflow/sflow_test.go
@@ -170,6 +170,44 @@ func TestSFlowDecodeDropExtendedACL(t *testing.T) {
 	assert.Equal(t, ExtendedACL{Number: 42, Name: "foo!", Direction: 2}, sample.Records[0].Data)
 }
 
+func TestSFlowDecodeSampledEthernet(t *testing.T) {
+	// Regression test for the SampledEthernet (flow data format 2) decoder.
+	// Per sFlow v5 (RFC 3176), each MAC address is encoded as XDR opaque
+	// fixed-length padded to a multiple of 4 bytes — so a 6-byte MAC is
+	// transmitted as 8 bytes (6 bytes of address + 2 zero pad bytes).
+	// Prior to the fix, DstMac was returned as 00:00:11:22:33:44 instead
+	// of 11:22:33:44:55:66 because the decoder treated SrcMac/DstMac as
+	// 6-byte fields with no padding.
+	//
+	// Wire format (24 bytes for SampledEthernet):
+	//   Length (u32, 4)
+	//   SrcMac (6 bytes + 2 pad = 8)
+	//   DstMac (6 bytes + 2 pad = 8)
+	//   EthType (u32, 4)
+	payload := bytes.NewBuffer(nil)
+	// Length = 1500
+	payload.Write([]byte{0x00, 0x00, 0x05, 0xdc})
+	// SrcMac with XDR pad
+	payload.Write([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x00})
+	// DstMac with XDR pad
+	payload.Write([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00})
+	// EthType = 0x0800 (IPv4)
+	payload.Write([]byte{0x00, 0x00, 0x08, 0x00})
+
+	header := &RecordHeader{DataFormat: FLOW_TYPE_ETH}
+	flowRecord, err := DecodeFlowRecord(header, payload)
+	assert.NoError(t, err)
+
+	eth, ok := flowRecord.Data.(SampledEthernet)
+	assert.True(t, ok)
+	assert.Equal(t, uint32(1500), eth.Length)
+	assert.Equal(t, []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, []byte(eth.SrcMac))
+	assert.Equal(t, []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}, []byte(eth.DstMac))
+	assert.Equal(t, uint32(0x0800), eth.EthType)
+	// Payload must be fully consumed.
+	assert.Equal(t, 0, payload.Len())
+}
+
 func TestSFlowDecodeDropExtendedFunction(t *testing.T) {
 	data := []byte{
 		0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x01, 0xc0, 0xa8, 0x77, 0xb8, 0x00, 0x01, 0x86, 0xa0,


### PR DESCRIPTION
Fixes #510.

Per sFlow v5 (RFC 3176), each MAC address in the `SampledEthernet` flow record is encoded as XDR opaque fixed-length, padded to a multiple of 4 bytes. A 6-byte MAC is transmitted as 8 bytes (6 bytes of address + 2 zero pad bytes).

The decoder in `decoders/sflow/sflow.go` previously read `SrcMac` and `DstMac` as 6-byte fields with no padding, so `SrcMac` came out correct but `DstMac` was shifted by 2 bytes — a wire `DstMac` of `11:22:33:44:55:66` was returned as `00:00:11:22:33:44`. The encoder in `decoders/sflow/encode.go` had the same omission.

Both sides now read/write 8 bytes per MAC (6 address + 2 pad) and a regression test in `sflow_test.go` covers the wire format.