### PR TITLE
fix(compose): use active Kafka image for single-node stack

### DIFF
--- a/compose/kcg/docker-compose.yml
+++ b/compose/kcg/docker-compose.yml
@@ -1,23 +1,23 @@
 version: "3"
 services:
-  zookeeper:
-    image: bitnami/zookeeper:3.7.1
-    ports:
-      - 2181:2181
-    environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
-    restart: always
   kafka:
-    image: bitnami/kafka:3.4.0
+    image: apache/kafka:3.9.0
     ports:
       - 9092:9092
     environment:
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_DELETE_TOPIC_ENABLE=true
+      - KAFKA_BROKER_ID=1
+      - KAFKA_NODE_ID=1
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=IB
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,BROKER:PLAINTEXT,IB:PLAINTEXT
+      - KAFKA_LISTENERS=CONTROLLER://:9093,BROKER://:9092,IB://:9094
+      - KAFKA_ADVERTISED_LISTENERS=BROKER://kafka:9092,IB://:9094
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     restart: always
-    depends_on:
-      - zookeeper
   grafana:
     image: grafana/grafana:9.4.3
     environment:


### PR DESCRIPTION
Updates the v1 compose stack to match the active Apache Kafka single-node setup used by the other branches.
This removes the inactive Bitnami Kafka/Zookeeper services, uses apache/kafka:3.9.0 with the same KRaft listener configuration as v2/main, and keeps KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 so Kafka can create the __consumer_offsets internal topic used by ClickHouse's Kafka consumer group.
Verification:
- git diff --check