### PR TITLE
fix(sflow): align SampledEthernet MAC padding on v2

### DIFF
--- a/decoders/sflow/sflow.go
+++ b/decoders/sflow/sflow.go
@@ -200,14 +200,18 @@ func DecodeFlowRecord(header *RecordHeader, payload *bytes.Buffer) (FlowRecord, 
 		sampledHeader.HeaderData = payload.Bytes()
 		flowRecord.Data = sampledHeader
 	case FLOW_TYPE_ETH:
+		// MAC addresses are XDR-padded to 8 bytes (6 bytes + 2 zero pad bytes).
 		sampledEth := SampledEthernet{
 			SrcMac: make([]byte, 6),
 			DstMac: make([]byte, 6),
 		}
+		var srcMacPad, dstMacPad uint16
 		if err := utils.BinaryDecoder(payload,
 			&sampledEth.Length,
 			sampledEth.SrcMac,
+			&srcMacPad,
 			sampledEth.DstMac,
+			&dstMacPad,
 			&sampledEth.EthType,
 		); err != nil {
 			return flowRecord, &RecordError{header.DataFormat, err}

--- a/decoders/sflow/sflow_test.go
+++ b/decoders/sflow/sflow_test.go
@@ -170,6 +170,25 @@ func TestSFlowDecodeDropExtendedACL(t *testing.T) {
 	assert.Equal(t, ExtendedACL{Number: 42, Name: "foo!", Direction: 2}, sample.Records[0].Data)
 }
 
+func TestSFlowDecodeSampledEthernet(t *testing.T) {
+	payload := bytes.NewBuffer(nil)
+	payload.Write([]byte{0x00, 0x00, 0x05, 0xdc})
+	payload.Write([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x00})
+	payload.Write([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00})
+	payload.Write([]byte{0x00, 0x00, 0x08, 0x00})
+
+	flowRecord, err := DecodeFlowRecord(&RecordHeader{DataFormat: FLOW_TYPE_ETH}, payload)
+	assert.NoError(t, err)
+
+	eth, ok := flowRecord.Data.(SampledEthernet)
+	assert.True(t, ok)
+	assert.Equal(t, uint32(1500), eth.Length)
+	assert.Equal(t, []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, []byte(eth.SrcMac))
+	assert.Equal(t, []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}, []byte(eth.DstMac))
+	assert.Equal(t, uint32(0x0800), eth.EthType)
+	assert.Equal(t, 0, payload.Len())
+}
+
 func TestSFlowDecodeDropExtendedFunction(t *testing.T) {
 	data := []byte{
 		0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x01, 0xc0, 0xa8, 0x77, 0xb8, 0x00, 0x01, 0x86, 0xa0,


### PR DESCRIPTION
## Summary
- consume the 2-byte XDR pad after each SampledEthernet MAC address on v2
- add a regression test covering padded source/destination MAC decode

## Tests
- go test ./decoders/sflow
- go test ./...
See #511