### PR TITLE
fix(sflow): align XDR encoder helpers with decoder

### DIFF
--- a/decoders/sflow/encode.go
+++ b/decoders/sflow/encode.go
@@ -353,6 +353,9 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 		if _, err := payload.Write(data.HeaderData); err != nil {
 			return err
 		}
+		if err := writeXDRPadding(payload, data.OriginalLength); err != nil {
+			return err
+		}
 	case *SampledHeader:
 		if dataFormat == 0 {
 			dataFormat = FLOW_TYPE_RAW
@@ -370,6 +373,9 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 			return err
 		}
 		if _, err := payload.Write(data.HeaderData); err != nil {
+			return err
+		}
+		if err := writeXDRPadding(payload, data.OriginalLength); err != nil {
 			return err
 		}
 	case SampledEthernet:
@@ -569,7 +575,7 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 		if err := utils.WriteU32(payload, data.Number); err != nil {
 			return err
 		}
-		if err := utils.WriteString(payload, data.Name); err != nil {
+		if err := writeXDRString(payload, data.Name); err != nil {
 			return err
 		}
 		if err := utils.WriteU32(payload, data.Direction); err != nil {
@@ -582,7 +588,7 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 		if err := utils.WriteU32(payload, data.Number); err != nil {
 			return err
 		}
-		if err := utils.WriteString(payload, data.Name); err != nil {
+		if err := writeXDRString(payload, data.Name); err != nil {
 			return err
 		}
 		if err := utils.WriteU32(payload, data.Direction); err != nil {
@@ -592,14 +598,14 @@ func encodeFlowRecord(buf *bytes.Buffer, record *FlowRecord) error {
 		if dataFormat == 0 {
 			dataFormat = FLOW_TYPE_EXT_FUNCTION
 		}
-		if err := utils.WriteString(payload, data.Symbol); err != nil {
+		if err := writeXDRString(payload, data.Symbol); err != nil {
 			return err
 		}
 	case *ExtendedFunction:
 		if dataFormat == 0 {
 			dataFormat = FLOW_TYPE_EXT_FUNCTION
 		}
-		if err := utils.WriteString(payload, data.Symbol); err != nil {
+		if err := writeXDRString(payload, data.Symbol); err != nil {
 			return err
 		}
 	case RawRecord:

--- a/decoders/sflow/encode_test.go
+++ b/decoders/sflow/encode_test.go
@@ -10,16 +10,16 @@ import (
 
 func TestEncodeDecodeSFlow(t *testing.T) {
 	packet := Packet{
-		Version:   5,
-		IPVersion: 1,
-		AgentIP:   utils.IPAddress{192, 0, 2, 1},
+		Version:        5,
+		IPVersion:      1,
+		AgentIP:        utils.IPAddress{192, 0, 2, 1},
 		SubAgentId:     1,
 		SequenceNumber: 2,
 		Uptime:         3,
 		Samples: []interface{}{
 			FlowSample{
 				Header: SampleHeader{
-					Format:              SAMPLE_FORMAT_FLOW,
+					Format:               SAMPLE_FORMAT_FLOW,
 					SampleSequenceNumber: 42,
 					SourceIdType:         0,
 					SourceIdValue:        7,
@@ -39,7 +39,7 @@ func TestEncodeDecodeSFlow(t *testing.T) {
 							Protocol:       1,
 							FrameLength:    64,
 							Stripped:       0,
-							OriginalLength: 64,
+							OriginalLength: 4,
 							HeaderData:     []byte{0xde, 0xad, 0xbe, 0xef},
 						},
 					},

--- a/decoders/sflow/xdr.go
+++ b/decoders/sflow/xdr.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/netsampler/goflow2/v2/decoders/utils"
+	"github.com/netsampler/goflow2/v3/decoders/utils"
 )
 
 func readXDROpaque(payload *bytes.Buffer) ([]byte, error) {
@@ -36,4 +36,27 @@ func readXDRString(payload *bytes.Buffer) (string, error) {
 		return "", err
 	}
 	return string(data), nil
+}
+
+func writeXDROpaque(payload *bytes.Buffer, data []byte) error {
+	if err := utils.WriteU32(payload, uint32(len(data))); err != nil {
+		return err
+	}
+	if _, err := payload.Write(data); err != nil {
+		return err
+	}
+	return writeXDRPadding(payload, uint32(len(data)))
+}
+
+func writeXDRString(payload *bytes.Buffer, value string) error {
+	return writeXDROpaque(payload, []byte(value))
+}
+
+func writeXDRPadding(payload *bytes.Buffer, length uint32) error {
+	padding := (4 - (length % 4)) % 4
+	if padding == 0 {
+		return nil
+	}
+	_, err := payload.Write(make([]byte, padding))
+	return err
 }


### PR DESCRIPTION
## Summary
- fix the sFlow XDR helper import to use the v3 module path
- add encoder helpers for XDR opaque/string padding
- make sampled raw headers and ACL/function strings encode in the same XDR layout expected by the decoder

## Tests
- go test ./decoders/sflow
- go test ./...