### PR TITLE
fix(transport): Send message and separator in one write call

### DIFF
--- a/transport/file/transport.go
+++ b/transport/file/transport.go
@@ -85,17 +85,16 @@ func (d *FileDriver) Send(key, data []byte) error {
 	d.lock.RLock()
 	w := d.w
 	d.lock.RUnlock()
+	if d.lineSeparator != "" {
+		buf := make([]byte, 0, len(data)+len(d.lineSeparator))
+		buf = append(buf, data...)
+		buf = append(buf, d.lineSeparator...)
+		data = buf
+	}
 	if len(data) > 0 {
 		if _, err := w.Write(data); err != nil {
 			return fmt.Errorf("write message: %w", err)
 		}
-	}
-	if d.lineSeparator == "" {
-		return nil
-	}
-	_, err := w.Write([]byte(d.lineSeparator))
-	if err != nil {
-		return fmt.Errorf("write separator: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
With multiple workers, a second message can get written before the `lineSeparator` can, resulting in parsers counting on the separator to fail intermittently. It doesn't happen for every message, but it's enough to measure consistently.

Expected:
```
"{...}\n{...}\n{...}\n"
```

Observed:
```
"{...}\n{...}{...}\n\n"
```

It seems like this was introduced with #447 when `data` and `lineSeparator` were separated into two writes.